### PR TITLE
WIP: update tekton integration test image

### DIFF
--- a/.tekton/multiarch-tuning-operator-integration-tests.yaml
+++ b/.tekton/multiarch-tuning-operator-integration-tests.yaml
@@ -12,7 +12,7 @@ spec:
           - name: source
             emptyDir: { }
         steps:
-          - image: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23
+          - image: registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23
             env:
               - name: URL
                 valueFrom:


### PR DESCRIPTION
`the step "unnamed-0" in TaskRun "multiarch-tuningc903e10ce302b7ddfcc5f32a08e5bd18-clone-and-test" failed to pull the image "". The pod errored with the message: "Back-off pulling image "brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23"."`

But image exists