### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multiarch-tuning-operator-v1-x

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -35,7 +35,8 @@ COPY LICENSE /licenses/license.txt
 USER 65532:65532
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator"
+LABEL name="multiarch-tuning/multiarch-tuning-rhel9-operator"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL release="1.2.0"
 LABEL version="1.2.0"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
