### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multiarch-tuning-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ FROM ${RUNTIME_IMAGE}
 
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator-bundle"
+LABEL name="multiarch-tuning/multiarch-tuning-operator-bundle"
 LABEL release="1.1.1"
 LABEL version="1.1.1"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -23,9 +23,10 @@ COPY bundle/tests/scorecard /tests/scorecard/
 # Labels from hack/patch-bundle-dockerfile.sh
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator-bundle"
+LABEL name="multiarch-tuning/multiarch-tuning-operator-bundle"
 LABEL release="1.1.1"
 LABEL version="1.1.1"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -35,9 +35,10 @@ COPY --from=builder /code/bundle/tests/scorecard /tests/scorecard/
 # Labels from hack/patch-bundle-dockerfile.sh
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator-bundle"
+LABEL name="multiarch-tuning/multiarch-tuning-operator-bundle"
 LABEL release="1.1.1"
 LABEL version="1.1.1"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \

--- a/hack/patch-bundle-dockerfile.sh
+++ b/hack/patch-bundle-dockerfile.sh
@@ -5,9 +5,10 @@
 CONTENT='# Labels from hack/patch-bundle-dockerfile.sh
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator-bundle"
+LABEL name="multiarch-tuning/multiarch-tuning-operator-bundle"
 LABEL release="'"${VERSION:-0.9.0}"'"
 LABEL version="'"${VERSION:-0.9.0}"'"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -33,9 +33,10 @@ COPY LICENSE /licenses/license.txt
 USER 65532:65532
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
-LABEL name="multiarch-tuning-operator"
+LABEL name="multiarch-tuning/multiarch-tuning-rhel9-operator"
 LABEL release="1.1.1"
 LABEL version="1.1.1"
+LABEL cpe="cpe:/a:redhat:multiarch_tuning_operator:1.1::el9"
 LABEL url="https://github.com/openshift/multiarch-tuning-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also https://github.com/release-engineering/rhtap-ec-policy/pull/149

Manual Cherry pick for 
https://github.com/openshift/multiarch-tuning-operator/pull/30
https://github.com/openshift/multiarch-tuning-operator/pull/20
