### PR TITLE
 Remove devel tag

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
       - name: name
         value: docker-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:devel@sha256:b24402e476665b242040b0f7cb6cd21b775e2e835192c1d03566eed6473afb20
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:b24402e476665b242040b0f7cb6cd21b775e2e835192c1d03566eed6473afb20
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -43,7 +43,7 @@ spec:
       - name: name
         value: docker-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:devel@sha256:b24402e476665b242040b0f7cb6cd21b775e2e835192c1d03566eed6473afb20
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:b24402e476665b242040b0f7cb6cd21b775e2e835192c1d03566eed6473afb20
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: docker-build-multi-platform-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel@sha256:33727f2c1da1e1563e2b3108fb620c3ed64acfcc9830e53666b9789758b3ff9c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:33727f2c1da1e1563e2b3108fb620c3ed64acfcc9830e53666b9789758b3ff9c
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -45,7 +45,7 @@ spec:
       - name: name
         value: docker-build-multi-platform-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel@sha256:33727f2c1da1e1563e2b3108fb620c3ed64acfcc9830e53666b9789758b3ff9c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:33727f2c1da1e1563e2b3108fb620c3ed64acfcc9830e53666b9789758b3ff9c
       - name: kind
         value: pipeline
   workspaces:


### PR DESCRIPTION
To fix the following error found in https://github.com/openshift/multiarch-tuning-operator/pull/63

```

Command failed: pipeline-migration-tool migrate -f "$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE"
ERROR:2025-11-01 08:37:45,539:cli:Cannot do migration for pipeline. Reason: InvalidVersion("Invalid version: 'devel'")
Traceback (most recent call last):
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/cli.py", line 24, in entry_point
    main()
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/cli.py", line 19, in main
    args.action(args)
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 717, in action
    migrate(upgrades, resolver_class)
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 470, in migrate
    manager.resolve_migrations()
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 411, in resolve_migrations
    self._resolver.resolve(list(self._task_bundle_upgrades.values()))
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 502, in resolve
    future.result()
  File "/usr/lib64/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib64/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 492, in _resolve
    upgrades_range = determine_task_bundle_upgrades_range(tb_upgrade)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 260, in determine_task_bundle_upgrades_range
    only_tags_pinned_by_version_revision(list_bundle_tags(task_bundle_upgrade)),
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 133, in list_bundle_tags
    versions = expand_versions(bundle_upgrade.current_value, bundle_upgrade.new_value)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/pipeline_migration/actions/migrate.py", line 125, in expand_versions
    from_version = parse_version(from_)
                   ^^^^^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/packaging/version.py", line 56, in parse
    return Version(version)
           ^^^^^^^^^^^^^^^^
  File "/home/renovate/.local/share/pipx/venvs/pipeline-migration-tool/lib64/python3.12/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: 'devel'
```
