### PR TITLE
MULTIARCH-5537: Fix kustomization catalog image to use Prow-built image for downstream main branch

### DIFF
--- a/deploy/envs/prow/kustomization.yaml
+++ b/deploy/envs/prow/kustomization.yaml
@@ -13,4 +13,14 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/multi-arch/multiarch-tuning-operator:catalog
+        value: registry.ci.openshift.org/ocp/multiarch-tuning-operator-catalog:main
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: openshift-multiarch-tuning-operator
+      namespace: openshift-multiarch-tuning-operator
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: main


### PR DESCRIPTION
Fix kustomization catalog image to use Prow-built image `registry.ci.openshift.org/ocp/multiarch-tuning-operator-catalog:main` for downstream main branch