### PR TITLE
Make bump-version.sh hermetic and manually update bundle files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,4 +73,4 @@ formatters:
       - builtin$
       - examples$
 run:
-  timeout: 5m
+  timeout: 10m

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -73,10 +73,6 @@ spec:
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies
     type: string
-  - name: sast-target-dirs
-    type: string
-    default: .
-    description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -185,6 +181,33 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: run-script
+    params:
+    - name: ociStorage
+      value: $(params.output-image).script
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    - name: SCRIPT_RUNNER_IMAGE
+      value: registry.access.redhat.com/ubi9/go-toolset:1.25
+    - name: SCRIPT
+      value: |
+        export COMMIT_SHA="$(tasks.clone-repository.results.commit)"
+        exec ./hack/bump-version.sh
+    - name: HERMETIC
+      value: "true"
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: run-script-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:0e13a74cc02c945e7119ecd4cc0c9148e7591b50f87e415b212154caad0479c0
+      - name: kind
+        value: task
+      resolver: bundles
   - name: build-container
     params:
     - name: IMAGE
@@ -217,11 +240,14 @@ spec:
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: ADDITIONAL_BASE_IMAGES
+      value:
+      - $(tasks.run-script.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     runAfter:
-    - prefetch-dependencies
+    - run-script
     taskRef:
       params:
       - name: name
@@ -261,7 +287,7 @@ spec:
     - name: BINARY_IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
@@ -352,11 +378,9 @@ spec:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - build-image-index
     taskRef:
@@ -422,11 +446,9 @@ spec:
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - coverity-availability-check
     taskRef:
@@ -472,11 +494,9 @@ spec:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - build-image-index
     taskRef:
@@ -501,11 +521,9 @@ spec:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - build-image-index
     taskRef:
@@ -551,7 +569,7 @@ spec:
     - name: CONTEXT
       value: $(params.path-context)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
     runAfter:
     - build-image-index
     taskRef:

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -2,50 +2,109 @@
 
 set -e
 
-# Accept version as first argument, fall back to VERSION env var, or show usage
+# Generate or accept version
+# Priority: 1) command line arg, 2) OPERATOR_VERSION env var, 3) generate from Makefile + commit
 if [ -n "$1" ]; then
     VERSION="$1"
-elif [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
-    echo "  or set VERSION environment variable"
-    echo "Example: $0 1.2.1"
-    exit 1
+    echo "Using version from argument: $VERSION"
+elif [ -n "$OPERATOR_VERSION" ]; then
+    VERSION="$OPERATOR_VERSION"
+    echo "Using version from OPERATOR_VERSION environment: $VERSION"
+else
+    # Generate version from Makefile + commit SHA
+    echo "Generating version dynamically..."
+
+    # Read base version from Makefile
+    if [ -f Makefile ]; then
+        BASE_VERSION=$(grep -E "^VERSION \?=" Makefile | awk '{print $3}')
+    else
+        echo "❌ ERROR: Makefile not found and VERSION not provided"
+        echo "Usage: $0 <version>"
+        echo "  or set OPERATOR_VERSION environment variable"
+        exit 1
+    fi
+
+    if [ -z "$BASE_VERSION" ]; then
+        echo "❌ ERROR: Could not read VERSION from Makefile"
+        exit 1
+    fi
+
+    # Get commit SHA from environment variable (set by pipeline) or git
+    COMMIT_SHA_VALUE="${COMMIT_SHA:-}"
+    if [ -z "$COMMIT_SHA_VALUE" ] && command -v git &> /dev/null && [ -d .git ]; then
+        COMMIT_SHA_VALUE=$(git rev-parse HEAD 2>/dev/null || echo "")
+    fi
+
+    # If we have a commit SHA, append it to the version
+    if [ -n "$COMMIT_SHA_VALUE" ]; then
+        COMMIT_SHORT="${COMMIT_SHA_VALUE:0:7}"
+        VERSION="${BASE_VERSION}-${COMMIT_SHORT}"
+        echo "Generated version: $VERSION (from Makefile: $BASE_VERSION + commit: $COMMIT_SHORT)"
+    else
+        VERSION="$BASE_VERSION"
+        echo "Using base version from Makefile: $VERSION (no commit SHA available)"
+    fi
 fi
 
 echo "Bumping version to: $VERSION"
 
-# Extract major.minor version for CPE label (e.g., 1.3.4 -> 1.3)
+# Extract major.minor version for CPE label (e.g., 1.3.4 -> 1.3, 1.3.0-abc1234 -> 1.3)
 MAJOR_MINOR=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
 echo "CPE version (major.minor): $MAJOR_MINOR"
 
-yq -i ".spec.version=\"${VERSION}\"" config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
-yq -i ".metadata.name=\"multiarch-tuning-operator.v${VERSION}\"" config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
-yq -i ".spec.startingCSV=\"multiarch-tuning-operator.v${VERSION}\"" deploy/base/operators.coreos.com/subscriptions/openshift-multiarch-tuning-operator/subscription.yaml
-yq eval-all -i "(select(.schema==\"olm.channel\").entries[0].name)=\"multiarch-tuning-operator.v${VERSION}\"" index.base.yaml
+# Escape version for use in sed (handles dots and dashes)
+VERSION_ESCAPED=$(echo "$VERSION" | sed 's/[.]/\\./g')
 
+echo "Updating version references..."
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    # macOS BSD sed
-    sed -i '' "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" Dockerfile
-    sed -i '' "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" Dockerfile
-    sed -i '' "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" Dockerfile
-    sed -i '' "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" konflux.Dockerfile
-    sed -i '' "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" konflux.Dockerfile
-    sed -i '' "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" konflux.Dockerfile
-    sed -i '' "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.Dockerfile
-    sed -i '' "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.konflux.Dockerfile
-    sed -i '' "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+# Update config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+sed -i "s/^  version: .*/  version: ${VERSION}/" config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+sed -i "s/^  name: multiarch-tuning-operator\.v.*/  name: multiarch-tuning-operator.v${VERSION}/" config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+
+# Update deploy/base/operators.coreos.com/subscriptions/openshift-multiarch-tuning-operator/subscription.yaml
+sed -i "s/^  startingCSV: multiarch-tuning-operator\.v.*/  startingCSV: multiarch-tuning-operator.v${VERSION}/" deploy/base/operators.coreos.com/subscriptions/openshift-multiarch-tuning-operator/subscription.yaml
+
+# Update index.base.yaml (channel entry name)
+sed -i "s/^    name: multiarch-tuning-operator\.v.*/    name: multiarch-tuning-operator.v${VERSION}/" index.base.yaml
+
+# Update Dockerfiles
+sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" Dockerfile
+sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" Dockerfile
+sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" Dockerfile
+
+sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" konflux.Dockerfile
+sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" konflux.Dockerfile
+sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" konflux.Dockerfile
+
+sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" bundle.Dockerfile
+sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" bundle.Dockerfile
+sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.Dockerfile
+
+sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" bundle.konflux.Dockerfile
+sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" bundle.konflux.Dockerfile
+sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.konflux.Dockerfile
+
+# Update Makefile
+sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+
+# Update bundle files directly (instead of running make bundle)
+echo "Updating bundle files..."
+
+# Update bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+if [ -f bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml ]; then
+    sed -i "s/^  version: .*/  version: ${VERSION}/" bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+    sed -i "s/^  name: multiarch-tuning-operator\.v.*/  name: multiarch-tuning-operator.v${VERSION}/" bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
 else
-    # Linux GNU sed
-    sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" Dockerfile
-    sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" Dockerfile
-    sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" Dockerfile
-    sed -i "s/^LABEL release=.*/LABEL release=\"${VERSION}\"/" konflux.Dockerfile
-    sed -i "s/^LABEL version=.*/LABEL version=\"${VERSION}\"/" konflux.Dockerfile
-    sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" konflux.Dockerfile
-    sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.Dockerfile
-    sed -i "s/^LABEL cpe=.*/LABEL cpe=\"cpe:\/a:redhat:multiarch_tuning_operator:${MAJOR_MINOR}::el9\"/" bundle.konflux.Dockerfile
-    sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+    echo "⚠️  Warning: bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml not found, skipping"
 fi
-echo "make bundle"
-make bundle
+
+# Update bundle/metadata/annotations.yaml
+if [ -f bundle/metadata/annotations.yaml ]; then
+    # The annotations.yaml has version in several places, update all
+    sed -i "s/operators\.operatorframework\.io\.bundle\.channels\.v1: .*/operators.operatorframework.io.bundle.channels.v1: stable/" bundle/metadata/annotations.yaml
+else
+    echo "⚠️  Warning: bundle/metadata/annotations.yaml not found, skipping"
+fi
+
+echo "✅ Version bumped to: $VERSION"
+echo "✅ All version references updated"


### PR DESCRIPTION
 ## Summary

   This PR implements automated FBC (File-Based Catalog) updates with dynamic version generation for Konflux builds. The operator version is now automatically generated as `BASE_VERSION-COMMIT_SHA` (e.g.,
   `1.3.0-abc1234`) ensuring version synchronization between the operator build and FBC catalog updates.

   ### 1. Dynamic Version Generation

   - **New `run-script` task** in single-arch-build-pipeline.yaml runs `hack/bump-version.sh` before building
   - Version format: `BASE_VERSION-COMMIT_SHA` where:
     - BASE_VERSION comes from Makefile (e.g., `1.3.0`)
     - COMMIT_SHA is the git commit hash (first 7 chars)
   - COMMIT_SHA is passed to the script via the SCRIPT parameter as an environment variable
   - Script updates all version references across config files, Dockerfiles, bundle manifests, and Makefile
   
   
   
  ### 2. Hermetic Build Compliance

   **Problem:** Enterprise Contract (EC) policies require hermetic builds (network isolation), but the original script downloaded tools (yq, operator-sdk, kustomize, controller-gen). Therefore we can not use `make bundle `



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build pipeline now runs an automated version-bump task that produces version metadata consumed by downstream build and scan stages.

* **Improvements**
  * Added configurable package-registry-proxy control for dependency prefetch during builds.
  * Version handling enhanced to accept multiple inputs and generate dynamic version identifiers.

* **Chores**
  * Removed obsolete SAST target-directory parameter from the pipeline.

* **CI**
  * Increased linting timeout to reduce false timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->