### PR TITLE
fix: Check channel entries only for patches in FBC update pipeline

### DIFF
--- a/.tekton/fbc-update-final-pipeline.yaml
+++ b/.tekton/fbc-update-final-pipeline.yaml
@@ -457,28 +457,31 @@ spec:
                       exit 1
                   fi
 
-                  # Check if other patches exist for this base
-                  COMMIT_VERSIONS_EXIST=false
-                  for check_file in fbc-v*/catalog/multiarch-tuning-operator/index.yaml; do
-                      if grep -q "name: multiarch-tuning-operator.v${BASE_VERSION}+" "$check_file"; then
-                          COMMIT_VERSIONS_EXIST=true
-                          break
-                      fi
-                  done
-
-                  if [ "$COMMIT_VERSIONS_EXIST" = true ]; then
-                      echo "Other patches exist for base $BASE_VERSION - will skip older patches"
-                      USE_SKIPS=true
-                  else
-                      echo "First patch for base $BASE_VERSION - will replace clean version"
-                      USE_SKIPS=false
-                  fi
               fi
 
               # Update each catalog's channel graph
               for index_file in fbc-v*/catalog/multiarch-tuning-operator/index.yaml; do
                   echo "Processing $index_file..."
                   temp_file=$(mktemp)
+
+                  # For patch versions, check if other patches exist in THIS catalog file's channel entries
+                  if [ "$IS_CLEAN_VERSION" = false ]; then
+                      # Check if other patches exist in this specific catalog file's channel section
+                      # Extract only the channel entries section to avoid matching bundle entries added by BUILD-INDEXES
+                      CHANNEL_PATCHES=$(awk '/^schema: olm.channel$/,/^schema:/ {print}' "$index_file" | \
+                          grep "name: multiarch-tuning-operator.v${BASE_VERSION}+" || true)
+
+                      if [ -n "$CHANNEL_PATCHES" ]; then
+                          echo "Other patches exist in $index_file channel - will skip older patches"
+                          USE_SKIPS=true
+                      else
+                          echo "First patch in $index_file channel - will replace clean version"
+                          USE_SKIPS=false
+                      fi
+                  else
+                      # Clean version never has skips
+                      USE_SKIPS=false
+                  fi
 
                   if [ "$USE_SKIPS" = true ]; then
                       # Adding a patch version when other patches exist


### PR DESCRIPTION
The skip logic was incorrectly matching bundle entries when checking for existing patches. The pipeline flow is:

1. BUILD-INDEXES adds bundle entries (schema: olm.bundle) to all catalogs
2. UPDATE-GRAPH checks if patches exist to determine skip logic
3. Previous code used grep that matched BOTH bundle and channel entries

This caused false positives: grep would find the bundle entry that was just added in step 1, set USE_SKIPS=true, then fail when trying to find patches in the channel entries (which don't exist yet for first patch).

Fixed by using awk to extract only the channel section (schema: olm.channel) before grepping for patches. Also moved the check inside the per-catalog loop to handle catalogs independently.

This fixes the error:
  "ERROR: USE_SKIPS=true but no existing patches found for base 1.3.0"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated patch version skip logic in the build pipeline to perform per-catalog-file checks instead of cross-catalog checks, enabling more granular control over version updates for non-clean versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->