### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,15 +12,22 @@
     "addLabels": [
       "approved",
       "lgtm"
+    ],
+    "schedule": [
+      "on saturday"
     ]
   },
   "packageRules": [
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26.0",
-      "schedule": [
-        "on saturday"
-      ]
+      "allowedVersions": "<1.26.0"
+    },
+    {
+      "matchDatasources": ["go"],
+      "matchManagers": ["gomod"],
+      "constraints": {
+        "go": "<1.26"
+      }
     }
   ],
   "pruneBranchAfterAutomerge": true,
@@ -35,6 +42,13 @@
     "addLabels": [
       "approved",
       "lgtm"
+    ],
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/"
+    ],
+    "includePaths": [
+      ".tekton/**"
     ]
   }
 }


### PR DESCRIPTION
Update renovate.json to limit the number of go updates and enable tekton updates for FBC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Renovate automation configuration with label assignment for tracked updates and refined weekend scheduling
  * Added version constraints for Go module dependencies to ensure system compatibility
  * Updated build configuration with improved file targeting and path-based inclusion patterns for CI/CD pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->