### PR TITLE
chore(tekton): enable multi-arch builds for FBC pipeline

### DIFF
--- a/.tekton/fbc-build-pipeline.yaml
+++ b/.tekton/fbc-build-pipeline.yaml
@@ -65,7 +65,10 @@ spec:
     name: build-args-file
     type: string
   - default:
-    - linux/x86_64
+    - localhost
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms


### PR DESCRIPTION
Update the fbc-build-pipeline default build-platforms from linux/x86_64 only to localhost, linux/arm64, linux/ppc64le, and linux/s390x to match the operator push pipeline's multi-arch configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to target additional CPU architectures (ARM64, PowerPC, System z, and localhost) in place of x86_64-only builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->