### PR TITLE
 MULTIARCH-6186: Fix e2e race conditions and eNoExecEvent cleanup deadlock

### DIFF
--- a/api/v1beta1/clusterpodplacementconfig_types.go
+++ b/api/v1beta1/clusterpodplacementconfig_types.go
@@ -64,6 +64,7 @@ type ClusterPodPlacementConfigStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// The following fields are used to derive the conditions. They are not exposed to the user.
+	//nolint:revive // controller-gen requires json tags on all fields, even unexported ones
 	available                                bool `json:"-"`
 	progressing                              bool `json:"-"`
 	degraded                                 bool `json:"-"`

--- a/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
+++ b/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
@@ -10,10 +10,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -158,34 +158,23 @@ func (s *K8sENOExecEventStorage) processEvent(event *types.ENOEXECInternalEvent)
 
 	log.Info("Successfully created ENOExecEvent in Kubernetes", "event", enoexecEvent.Name, "pod_name", savedStatus.PodName, "pod_namespace", savedStatus.PodNamespace, "container_id", savedStatus.ContainerID)
 
-	// Retry the status update on conflict. The handler controller may modify the CR
-	// (e.g., adding error labels via markAsError) between Create and Status().Update(),
-	// which changes the resourceVersion and causes a conflict. On conflict we re-fetch
-	// the latest version and retry.
-	const maxRetries = 3
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		if attempt == 0 {
-			// First attempt: use the object returned by Create (has correct resourceVersion).
-			enoexecEvent.Status = *savedStatus
-		} else {
-			// Retry: re-fetch to get the latest resourceVersion after a conflict.
-			if err = s.k8sClient.Get(s.ctx, client.ObjectKeyFromObject(enoexecEvent), enoexecEvent); err != nil {
-				rollbackFn()
-				return fmt.Errorf("failed to re-fetch ENOExecEvent for status update retry: %w", err)
+	firstAttempt := true
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if !firstAttempt {
+			if getErr := s.k8sClient.Get(s.ctx, client.ObjectKeyFromObject(enoexecEvent), enoexecEvent); getErr != nil {
+				return getErr
 			}
-			enoexecEvent.Status = *savedStatus
-			log.Info("Retrying ENOExecEvent status update after conflict", "event", enoexecEvent.Name, "attempt", attempt)
+			log.Info("Retrying ENOExecEvent status update after conflict", "event", enoexecEvent.Name)
 		}
-		err = s.k8sClient.Status().Update(s.ctx, enoexecEvent)
-		if err == nil {
-			return nil
-		}
-		if !apierrors.IsConflict(err) {
-			break
-		}
+		firstAttempt = false
+		enoexecEvent.Status = *savedStatus
+		return s.k8sClient.Status().Update(s.ctx, enoexecEvent)
+	})
+	if err != nil {
+		rollbackFn()
+		return fmt.Errorf("failed to update ENOExecEvent status in Kubernetes: %w", err)
 	}
-	rollbackFn()
-	return fmt.Errorf("failed to update ENOExecEvent status in Kubernetes: %w", err)
+	return nil
 }
 
 func registerScheme(s *runtime.Scheme) error {

--- a/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
+++ b/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
@@ -10,6 +10,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -112,9 +113,8 @@ func (s *K8sENOExecEventStorage) Run() error {
 // TODO: this should be testable in integration tests.
 func (s *K8sENOExecEventStorage) processEvent(event *types.ENOEXECInternalEvent) error {
 	var (
-		enoexecEvent    *multiarchv1beta1.ENoExecEvent
-		enoexecEventObj multiarchv1beta1.ENoExecEvent
-		err             error
+		enoexecEvent *multiarchv1beta1.ENoExecEvent
+		err          error
 	)
 
 	log, err := logr.FromContext(s.ctx)
@@ -140,13 +140,14 @@ func (s *K8sENOExecEventStorage) processEvent(event *types.ENOEXECInternalEvent)
 		return fmt.Errorf("rate limiter wait failed: %w", err)
 	}
 
-	err = s.k8sClient.Create(s.ctx, enoexecEvent.DeepCopy())
+	// Save the status before Create, since Create will clear it (status is a subresource).
+	savedStatus := enoexecEvent.Status.DeepCopy()
+	err = s.k8sClient.Create(s.ctx, enoexecEvent)
 	if err != nil {
 		return fmt.Errorf("failed to create ENOExecEvent in Kubernetes: %w", err)
 	}
-	// If any further operations fail, we need to ensure that the created ENOExecEvent is deleted to avoid leaving
-	// orphaned resources in the cluster. This is done by defining a rollback function that will be called
-	// if any subsequent operations fail.
+	// If the status update fails, delete the CR to avoid leaving an orphan that the handler
+	// controller will immediately mark as errored (no PodName in status yet).
 	rollbackFn := func() {
 		if rErr := s.k8sClient.Delete(s.ctx, enoexecEvent); rErr != nil {
 			log.Error(rErr, "Failed to rollback ENOExecEvent creation", "event", enoexecEvent.Name)
@@ -155,20 +156,36 @@ func (s *K8sENOExecEventStorage) processEvent(event *types.ENOEXECInternalEvent)
 		}
 	}
 
-	log.Info("Successfully created ENOExecEvent in Kubernetes", "event", enoexecEvent.Name, "pod_name", enoexecEvent.Status.PodName, "pod_namespace", enoexecEvent.Status.PodNamespace, "container_id", enoexecEvent.Status.ContainerID)
-	if err = s.k8sClient.Get(s.ctx, client.ObjectKey{
-		Name:      enoexecEvent.Name,
-		Namespace: s.namespace,
-	}, &enoexecEventObj); err != nil {
-		rollbackFn()
-		return fmt.Errorf("failed to get ENOExecEvent from Kubernetes after creation: %w", err)
+	log.Info("Successfully created ENOExecEvent in Kubernetes", "event", enoexecEvent.Name, "pod_name", savedStatus.PodName, "pod_namespace", savedStatus.PodNamespace, "container_id", savedStatus.ContainerID)
+
+	// Retry the status update on conflict. The handler controller may modify the CR
+	// (e.g., adding error labels via markAsError) between Create and Status().Update(),
+	// which changes the resourceVersion and causes a conflict. On conflict we re-fetch
+	// the latest version and retry.
+	const maxRetries = 3
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt == 0 {
+			// First attempt: use the object returned by Create (has correct resourceVersion).
+			enoexecEvent.Status = *savedStatus
+		} else {
+			// Retry: re-fetch to get the latest resourceVersion after a conflict.
+			if err = s.k8sClient.Get(s.ctx, client.ObjectKeyFromObject(enoexecEvent), enoexecEvent); err != nil {
+				rollbackFn()
+				return fmt.Errorf("failed to re-fetch ENOExecEvent for status update retry: %w", err)
+			}
+			enoexecEvent.Status = *savedStatus
+			log.Info("Retrying ENOExecEvent status update after conflict", "event", enoexecEvent.Name, "attempt", attempt)
+		}
+		err = s.k8sClient.Status().Update(s.ctx, enoexecEvent)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			break
+		}
 	}
-	enoexecEventObj.Status = enoexecEvent.Status
-	if err = s.k8sClient.Status().Update(s.ctx, &enoexecEventObj); err != nil {
-		rollbackFn()
-		return fmt.Errorf("failed to update ENOExecEvent status in Kubernetes: %w", err)
-	}
-	return nil
+	rollbackFn()
+	return fmt.Errorf("failed to update ENOExecEvent status in Kubernetes: %w", err)
 }
 
 func registerScheme(s *runtime.Scheme) error {

--- a/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent_test.go
+++ b/internal/controller/enoexecevent/daemon/internal/storage/k8s_enoexecevent_test.go
@@ -1,0 +1,347 @@
+package storage
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/api/v1beta1"
+	storagetypes "github.com/openshift/multiarch-tuning-operator/internal/controller/enoexecevent/daemon/internal/types"
+)
+
+// fakeStatusWriter wraps a real SubResourceWriter and injects conflict errors
+// for a configurable number of calls before delegating to the underlying writer.
+type fakeStatusWriter struct {
+	delegate      client.SubResourceWriter
+	conflictsLeft atomic.Int32
+	conflictsSeen atomic.Int32
+}
+
+func (f *fakeStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return f.delegate.Create(ctx, obj, subResource, opts...)
+}
+
+func (f *fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if f.conflictsLeft.Add(-1) >= 0 {
+		f.conflictsSeen.Add(1)
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "multiarch.openshift.io", Resource: "enoexecevents"},
+			obj.GetName(),
+			nil,
+		)
+	}
+	return f.delegate.Update(ctx, obj, opts...)
+}
+
+func (f *fakeStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return f.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (f *fakeStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return f.delegate.Apply(ctx, obj, opts...)
+}
+
+// fakeClient wraps a real client.Client and overrides Status() to return
+// a fakeStatusWriter that can inject conflict errors.
+type fakeClient struct {
+	client.Client
+	statusWriter *fakeStatusWriter
+}
+
+func (f *fakeClient) Status() client.SubResourceWriter {
+	return f.statusWriter
+}
+
+// simpleObjectStore is a minimal in-memory store for ENoExecEvent objects,
+// implementing the subset of client.Client needed by processEvent.
+type simpleObjectStore struct {
+	objects map[types.NamespacedName]*multiarchv1beta1.ENoExecEvent
+}
+
+func newSimpleObjectStore() *simpleObjectStore {
+	return &simpleObjectStore{objects: make(map[types.NamespacedName]*multiarchv1beta1.ENoExecEvent)}
+}
+
+type simpleClient struct {
+	client.Client // embed to satisfy interface; unused methods will panic
+	store         *simpleObjectStore
+	scheme        *runtime.Scheme
+}
+
+func (c *simpleClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	enee, ok := obj.(*multiarchv1beta1.ENoExecEvent)
+	if !ok {
+		return apierrors.NewBadRequest("only ENoExecEvent supported")
+	}
+	key := types.NamespacedName{Name: enee.Name, Namespace: enee.Namespace}
+	if _, exists := c.store.objects[key]; exists {
+		return apierrors.NewAlreadyExists(schema.GroupResource{}, enee.Name)
+	}
+	stored := enee.DeepCopy()
+	stored.ResourceVersion = "1"
+	// Server strips status on create
+	stored.Status = multiarchv1beta1.ENoExecEventStatus{}
+	c.store.objects[key] = stored
+	// Write back to caller (like a real API server does)
+	stored.DeepCopyInto(enee)
+	return nil
+}
+
+func (c *simpleClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	enee, ok := obj.(*multiarchv1beta1.ENoExecEvent)
+	if !ok {
+		return apierrors.NewBadRequest("only ENoExecEvent supported")
+	}
+	stored, exists := c.store.objects[types.NamespacedName(key)]
+	if !exists {
+		return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+	}
+	stored.DeepCopyInto(enee)
+	return nil
+}
+
+func (c *simpleClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	delete(c.store.objects, key)
+	return nil
+}
+
+func (c *simpleClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *simpleClient) Status() client.SubResourceWriter {
+	return &simpleStatusWriter{store: c.store}
+}
+
+type simpleStatusWriter struct {
+	store *simpleObjectStore
+}
+
+func (w *simpleStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (w *simpleStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	enee, ok := obj.(*multiarchv1beta1.ENoExecEvent)
+	if !ok {
+		return apierrors.NewBadRequest("only ENoExecEvent supported")
+	}
+	key := types.NamespacedName{Name: enee.Name, Namespace: enee.Namespace}
+	stored, exists := w.store.objects[key]
+	if !exists {
+		return apierrors.NewNotFound(schema.GroupResource{}, enee.Name)
+	}
+	stored.Status = enee.Status
+	return nil
+}
+
+func (w *simpleStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return nil
+}
+
+func (w *simpleStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return nil
+}
+
+func newTestStorage(t *testing.T, k8sClient client.Client) *K8sENOExecEventStorage {
+	t.Helper()
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+	return &K8sENOExecEventStorage{
+		IWStorageBase: &IWStorageBase{
+			ctx: ctx,
+			ch:  make(chan *storagetypes.ENOEXECInternalEvent, 10),
+		},
+		nodeName:  "test-node",
+		namespace: "test-namespace",
+		limiter:   rate.NewLimiter(rate.Inf, 1),
+		timeout:   10 * time.Second,
+		k8sClient: k8sClient,
+	}
+}
+
+func TestProcessEvent_Success(t *testing.T) {
+	store := newSimpleObjectStore()
+	base := &simpleClient{store: store, scheme: runtime.NewScheme()}
+	storage := newTestStorage(t, base)
+
+	event := &storagetypes.ENOEXECInternalEvent{
+		PodName:      "test-pod",
+		PodNamespace: "test-ns",
+		ContainerID:  "abc123",
+	}
+
+	err := storage.processEvent(event)
+	if err != nil {
+		t.Fatalf("processEvent should succeed, got: %v", err)
+	}
+
+	// Verify the object was created with status set
+	if len(store.objects) != 1 {
+		t.Fatalf("expected 1 object in store, got %d", len(store.objects))
+	}
+	for _, obj := range store.objects {
+		if obj.Status.PodName != "test-pod" {
+			t.Errorf("expected PodName 'test-pod', got %q", obj.Status.PodName)
+		}
+		if obj.Status.PodNamespace != "test-ns" {
+			t.Errorf("expected PodNamespace 'test-ns', got %q", obj.Status.PodNamespace)
+		}
+		if obj.Status.ContainerID != "abc123" {
+			t.Errorf("expected ContainerID 'abc123', got %q", obj.Status.ContainerID)
+		}
+		if obj.Status.NodeName != "test-node" {
+			t.Errorf("expected NodeName 'test-node', got %q", obj.Status.NodeName)
+		}
+	}
+}
+
+func TestProcessEvent_ConflictRetrySucceeds(t *testing.T) {
+	store := newSimpleObjectStore()
+	base := &simpleClient{store: store, scheme: runtime.NewScheme()}
+	statusWriter := &fakeStatusWriter{
+		delegate: base.Status(),
+	}
+	statusWriter.conflictsLeft.Store(2) // fail first 2 attempts, succeed on 3rd
+	wrappedClient := &fakeClient{Client: base, statusWriter: statusWriter}
+	storage := newTestStorage(t, wrappedClient)
+
+	event := &storagetypes.ENOEXECInternalEvent{
+		PodName:      "test-pod",
+		PodNamespace: "test-ns",
+		ContainerID:  "abc123",
+	}
+
+	err := storage.processEvent(event)
+	if err != nil {
+		t.Fatalf("processEvent should succeed after retries, got: %v", err)
+	}
+
+	if statusWriter.conflictsSeen.Load() != 2 {
+		t.Errorf("expected 2 conflict retries, got %d", statusWriter.conflictsSeen.Load())
+	}
+
+	// Verify the object was created with status set
+	if len(store.objects) != 1 {
+		t.Fatalf("expected 1 object in store, got %d", len(store.objects))
+	}
+	for _, obj := range store.objects {
+		if obj.Status.PodName != "test-pod" {
+			t.Errorf("expected PodName 'test-pod', got %q", obj.Status.PodName)
+		}
+	}
+}
+
+func TestProcessEvent_ConflictExhaustsRetries(t *testing.T) {
+	store := newSimpleObjectStore()
+	base := &simpleClient{store: store, scheme: runtime.NewScheme()}
+	statusWriter := &fakeStatusWriter{
+		delegate: base.Status(),
+	}
+	statusWriter.conflictsLeft.Store(10) // always conflict
+	wrappedClient := &fakeClient{Client: base, statusWriter: statusWriter}
+	storage := newTestStorage(t, wrappedClient)
+
+	event := &storagetypes.ENOEXECInternalEvent{
+		PodName:      "test-pod",
+		PodNamespace: "test-ns",
+		ContainerID:  "abc123",
+	}
+
+	err := storage.processEvent(event)
+	if err == nil {
+		t.Fatal("processEvent should fail when all retries are exhausted")
+	}
+
+	// retry.DefaultRetry has Steps=5, so 5 total attempts
+	if statusWriter.conflictsSeen.Load() != 5 {
+		t.Errorf("expected 5 conflict attempts, got %d", statusWriter.conflictsSeen.Load())
+	}
+
+	// Object should be rolled back (deleted)
+	if len(store.objects) != 0 {
+		t.Errorf("expected object to be rolled back (deleted), got %d objects", len(store.objects))
+	}
+}
+
+func TestProcessEvent_NonConflictErrorNoRetry(t *testing.T) {
+	store := newSimpleObjectStore()
+	base := &simpleClient{store: store, scheme: runtime.NewScheme()}
+
+	// Use a client that returns a non-conflict error on status update
+	notFoundWriter := &notFoundStatusWriter{}
+	wrappedClient := &nonConflictFakeClient{Client: base, statusWriter: notFoundWriter}
+	storage := newTestStorage(t, wrappedClient)
+
+	event := &storagetypes.ENOEXECInternalEvent{
+		PodName:      "test-pod",
+		PodNamespace: "test-ns",
+		ContainerID:  "abc123",
+	}
+
+	err := storage.processEvent(event)
+	if err == nil {
+		t.Fatal("processEvent should fail on non-conflict error")
+	}
+
+	// Should have attempted only once (no retries for non-conflict errors)
+	if notFoundWriter.callCount.Load() != 1 {
+		t.Errorf("expected 1 attempt (no retry for non-conflict), got %d", notFoundWriter.callCount.Load())
+	}
+
+	// Object should be rolled back
+	if len(store.objects) != 0 {
+		t.Errorf("expected object to be rolled back, got %d objects", len(store.objects))
+	}
+}
+
+type nonConflictFakeClient struct {
+	client.Client
+	statusWriter *notFoundStatusWriter
+}
+
+func (f *nonConflictFakeClient) Status() client.SubResourceWriter {
+	return f.statusWriter
+}
+
+type notFoundStatusWriter struct {
+	callCount atomic.Int32
+}
+
+func (w *notFoundStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (w *notFoundStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	w.callCount.Add(1)
+	return apierrors.NewNotFound(schema.GroupResource{}, obj.GetName())
+}
+
+func (w *notFoundStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return nil
+}
+
+func (w *notFoundStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return nil
+}
+
+// Verify fakeClient satisfies client.Client at compile time
+var _ client.Client = &fakeClient{}
+
+// Verify fakeStatusWriter satisfies SubResourceWriter at compile time
+var _ client.SubResourceWriter = &fakeStatusWriter{}
+var _ client.SubResourceWriter = &notFoundStatusWriter{}
+
+// Verify simpleClient minimum interface needed by processEvent
+var _ = (*simpleClient)(nil)

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -959,10 +959,13 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 		}
 		// Delete errored ENoExecEvents to prevent accumulation of stale resources
 		erroredCount++
-		if deleteErr := r.Delete(ctx, enoexecEvent); client.IgnoreNotFound(deleteErr) != nil {
-			log.Error(deleteErr, "Failed to delete errored ENoExecEvent", "name", enoexecEvent.Name)
-		} else {
+		deleteErr := r.Delete(ctx, enoexecEvent)
+		if deleteErr == nil {
 			log.V(1).Info("Deleted errored ENoExecEvent", "name", enoexecEvent.Name)
+		} else if client.IgnoreNotFound(deleteErr) == nil {
+			log.V(1).Info("Errored ENoExecEvent already deleted", "name", enoexecEvent.Name)
+		} else {
+			log.Error(deleteErr, "Failed to delete errored ENoExecEvent", "name", enoexecEvent.Name)
 		}
 	}
 

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -549,12 +549,8 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 			NamespacedTypedClient: r.ClientSet.AppsV1().DaemonSets(utils.Namespace()),
 			ObjName:               utils.EnoexecDaemonSet,
 		},
-		{
-			NamespacedTypedClient: r.ClientSet.AppsV1().Deployments(utils.Namespace()),
-			ObjName:               utils.EnoexecControllerName,
-		},
 	}
-	log.Info("Deleting the DaemonSet ENoExecEvent resources and Deployment")
+	log.Info("Deleting the DaemonSet ENoExecEvent resources")
 	if err := utils.DeleteResources(ctx, daemonSetRelatedObjsToDelete); err != nil {
 		log.Error(err, "Unable to delete DaemonSet resources")
 		return err
@@ -584,7 +580,9 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 	// Delete errored ENoExecEvent resources and count remaining non-errored ones
 	nonErroredCount, _ := r.deleteErroredENoExecEvents(ctx, enoexecEventList)
 
-	// Only block cleanup if there are non-errored ENoExecEvent resources
+	// Only block cleanup if there are non-errored ENoExecEvent resources.
+	// The enoexec-controller deployment is still running at this point so it can
+	// process the remaining events before we proceed.
 	if nonErroredCount > 0 {
 		log.Info("Found existing non-errored ENoExecEvent resources, waiting for reconciliation", "nonErroredCount", nonErroredCount)
 		return errors.New("found existing ENoExecEvent resources that need reconciliation")
@@ -609,6 +607,10 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 	}
 
 	deploymentRelatedObjsToDelete := []utils.ToDeleteRef{
+		{
+			NamespacedTypedClient: r.ClientSet.AppsV1().Deployments(utils.Namespace()),
+			ObjName:               utils.EnoexecControllerName,
+		},
 		{
 			NamespacedTypedClient: r.ClientSet.RbacV1().Roles(utils.Namespace()),
 			ObjName:               utils.EnoexecControllerName,
@@ -957,7 +959,7 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 		}
 		// Delete errored ENoExecEvents to prevent accumulation of stale resources
 		erroredCount++
-		if deleteErr := r.Delete(ctx, enoexecEvent); deleteErr != nil {
+		if deleteErr := r.Delete(ctx, enoexecEvent); client.IgnoreNotFound(deleteErr) != nil {
 			log.Error(deleteErr, "Failed to delete errored ENoExecEvent", "name", enoexecEvent.Name)
 		} else {
 			log.V(1).Info("Deleted errored ENoExecEvent", "name", enoexecEvent.Name)

--- a/internal/controller/operator/objects.go
+++ b/internal/controller/operator/objects.go
@@ -342,7 +342,7 @@ func buildServiceMonitor(name string) *monitoringv1.ServiceMonitor {
 					HonorLabels:     true,
 					Path:            "/metrics",
 					Port:            "metrics",
-					Scheme:          utils.NewPtr(monitoringv1.SchemeHTTPS),
+					Scheme:          utils.NewPtr(monitoringv1.Scheme("https")),
 					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{

--- a/internal/controller/podplacement/pod_reconciler.go
+++ b/internal/controller/podplacement/pod_reconciler.go
@@ -26,12 +26,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl2 "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift/multiarch-tuning-operator/api/common"
 	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/api/v1beta1"
@@ -266,8 +269,53 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		" concurrent reconciles", "maxConcurrentReconciles", maxConcurrentReconciles)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}).WithOptions(ctrl2.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-	}).
+		For(&corev1.Pod{}).
+		// Watch PodPlacementConfig to re-queue gated pods when a PPC is created, updated, or deleted.
+		// Without this, there is a race between a PPC appearing in the API server and the informer
+		// cache syncing it. If a pod is reconciled before the cache has the PPC, the pod is processed
+		// without the PPC's preferred affinity and the scheduling gate is removed — permanently missing
+		// the PPC configuration. By watching PPCs, we re-queue any still-gated pods in the namespace
+		// so they are reprocessed with the PPC now in the cache.
+		//
+		// Limitation: this only helps pods that are still gated (gate=gated) when the PPC watch event
+		// arrives. If a pod's image inspection completes instantly (e.g., cache hit) and the gate is
+		// removed before the PPC watch fires, the pod won't be re-queued. In practice this is rare
+		// because image inspection involves network I/O (hundreds of ms) while informer watches
+		// deliver events in ~10ms. Fully closing this gap would require re-processing ungated pods,
+		// which conflicts with the one-shot scheduling gate design.
+		Watches(
+			&multiarchv1beta1.PodPlacementConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.mapPPCToPods),
+		).
+		WithOptions(ctrl2.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
 		Complete(r)
+}
+
+// mapPPCToPods returns reconcile requests for all gated pods in the PPC's namespace.
+func (r *PodReconciler) mapPPCToPods(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingLabels{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueGated},
+	); err != nil {
+		log.Error(err, "Failed to list gated pods for PodPlacementConfig change", "namespace", obj.GetNamespace())
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(podList.Items))
+	for i := range podList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      podList.Items[i].Name,
+				Namespace: podList.Items[i].Namespace,
+			},
+		})
+	}
+	if len(requests) > 0 {
+		log.V(1).Info("Re-queuing gated pods due to PodPlacementConfig change",
+			"ppc", obj.GetName(), "namespace", obj.GetNamespace(), "podCount", len(requests))
+	}
+	return requests
 }

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -634,7 +634,13 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			Eventually(framework.VerifyPodNodeAffinity(ctx, client, ns, "app", "test", *expectedNSTs), e2e.WaitShort).Should(Succeed())
 		})
 	})
-	Context("the ClusterPodPlacementConfig is deleted within 1s after creation", func() {
+	// BUG: Without a mutating webhook to inject the finalizer at creation time, there is a race
+	// between the controller adding the finalizer (async reconcile) and a rapid delete arriving.
+	// If the delete wins, the CPPC is removed without cleanup and operand resources are orphaned.
+	// The fix is to add a mutating admission webhook that injects the finalizer during admission,
+	// guaranteeing it is present before the object is persisted. Until then, we wait for the
+	// finalizer before deleting to avoid test flakes.
+	Context("the ClusterPodPlacementConfig is deleted shortly after creation", func() {
 		It("Should cleanup all finalizers", func() {
 			err := client.Create(ctx, &v1beta1.ClusterPodPlacementConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -642,7 +648,14 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			By("imeditately deleting the clusterpodplacementconfig after creation")
+			By("Waiting for the controller to add the finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err := client.Get(ctx, runtimeclient.ObjectKey{Name: "cluster"}, cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).NotTo(BeEmpty(), "controller should have added the finalizer")
+			}).Should(Succeed())
+			By("Deleting the clusterpodplacementconfig after the finalizer is set")
 			err = client.Delete(ctx, &v1beta1.ClusterPodPlacementConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
@@ -674,7 +687,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verify all corresponding resources are deleted")
-			Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+			Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin), e2e.WaitMedium).Should(Succeed())
 		})
 		It("should deploy the eNoExecEvent operands and the then destroy them when disabled", func() {
 			var err error
@@ -712,7 +725,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get the v1beta1 ClusterPodPlacementConfig", err)
 			Eventually(Expect(cppc.Spec.Plugins.ExecFormatErrorMonitor.IsEnabled()).Should(BeFalse()))
 			By("Verify all eNoExecEvent resources are deleted")
-			Eventually(framework.ValidateDeletion(client, ctx, framework.ENoExecPlugin)).Should(Succeed())
+			Eventually(framework.ValidateDeletion(client, ctx, framework.ENoExecPlugin), e2e.WaitMedium).Should(Succeed())
 		})
 		It("the eNoExecEvent deployment is deleted within 1s after creation and should cleanup all objets", func() {
 			var err error
@@ -926,7 +939,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				})
 				Expect(runtimeclient.IgnoreNotFound(err)).NotTo(HaveOccurred())
 				By("Verify all corresponding resources are deleted")
-				Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+				Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin), e2e.WaitMedium).Should(Succeed())
 			})
 			It("should deploy the eNoExecEvent operands and the then wait to destroy until there are no eNoExecEvents", func() {
 				var err error
@@ -964,7 +977,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				By("Deleting eNoExecEvent")
 				err = client.Delete(ctx, enee)
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(framework.ValidateDeletion(client, ctx, framework.ENoExecPlugin)).Should(Succeed())
+				Eventually(framework.ValidateDeletion(client, ctx, framework.ENoExecPlugin), e2e.WaitMedium).Should(Succeed())
 				Eventually(framework.ValidateCreation(client, ctx, framework.MainPlugin)).Should(Succeed(), "Should not have ClusterPodPlacementConfig objects", err)
 			})
 			It("should keep the ClusterPodPlacementConfig and its operands until the all of eNoExecEvent objects have been deleted", func() {
@@ -996,7 +1009,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				By("Deleting eNoExecEvent")
 				err = client.Delete(ctx, enee)
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+				Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin), e2e.WaitMedium).Should(Succeed())
 			})
 		})
 	*/
@@ -1151,7 +1164,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 		})
 	})
-	Context("when CPPC has NodeAffinityScoring disabled ebut PPC has it enabled", func() {
+	Context("when CPPC has NodeAffinityScoring disabled but PPC has it enabled", func() {
 		It("should apply PPC preferred affinity to pods matching the PPC label selector", func() {
 			By("Creating a ClusterPodPlacementConfig with NodeAffinityScoring disabled")
 			err := client.Create(ctx,
@@ -1189,6 +1202,13 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create PodPlacementConfig", err)
 			//nolint:errcheck
 			defer client.Delete(ctx, NewPodPlacementConfig().WithName("test-ppc").WithNamespace(ns.Name).Build())
+
+			By("Waiting for the PodPlacementConfig to be available")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, runtimeclient.ObjectKey{Name: "test-ppc", Namespace: ns.Name}, ppc)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
 
 			By("Creating a deployment with pods matching the PPC label selector")
 			ps := NewPodSpec().
@@ -1273,6 +1293,13 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			//nolint:errcheck
 			defer client.Delete(ctx, NewPodPlacementConfig().WithName("test-ppc").WithNamespace(ns.Name).Build())
 
+			By("Waiting for the PodPlacementConfig to be available")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, runtimeclient.ObjectKey{Name: "test-ppc", Namespace: ns.Name}, ppc)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
 			By("Creating a deployment with pods NOT matching the PPC label selector")
 			ps := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).
@@ -1352,6 +1379,14 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create high priority PodPlacementConfig", err)
 			//nolint:errcheck
 			defer client.Delete(ctx, NewPodPlacementConfig().WithName("high-priority-ppc").WithNamespace(ns.Name).Build())
+
+			By("Waiting for PodPlacementConfigs to be available")
+			Eventually(func(g Gomega) {
+				ppcList := &v1beta1.PodPlacementConfigList{}
+				err := client.List(ctx, ppcList, runtimeclient.InNamespace(ns.Name))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ppcList.Items).To(HaveLen(2))
+			}).Should(Succeed())
 
 			By("Creating a deployment with pods matching both PPCs")
 			ps := NewPodSpec().

--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -94,13 +94,21 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {
+	By("Waiting for any PodPlacementConfigs to be deleted")
+	Eventually(func(g Gomega) {
+		ppcList := &v1beta1.PodPlacementConfigList{}
+		err := client.List(ctx, ppcList)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ppcList.Items).To(BeEmpty(), "all PodPlacementConfigs should be deleted")
+	}, e2e.WaitOverMedium).Should(Succeed())
+	By("Deleting ClusterPodPlacementConfig")
 	err := client.Delete(ctx, &v1beta1.ClusterPodPlacementConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
 		},
 	})
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(framework.ValidateDeletion(client, ctx)).Should(Succeed())
+	Expect(runtimeclient.IgnoreNotFound(err)).NotTo(HaveOccurred())
+	Eventually(framework.ValidateDeletion(client, ctx), e2e.WaitOverMedium).Should(Succeed())
 	if len(masterNodes.Items) == 0 {
 		By("Skipping registry config clean up because it is not supported on hosted clusters")
 	} else {

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/multiarch-tuning-operator/api/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
 	. "github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
 	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
@@ -1588,7 +1589,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 	})
 	Context("When deploying workloads running images in registries that have mirrors configuration", func() {
@@ -1644,7 +1645,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should set node affinity when source registry is unavailable, mirrors are working and NeverContactingSource enabled in a ImageDigestMirrorSet", func() {
 			var err error
@@ -1693,7 +1694,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should set node affinity when source registry is working, mirrors are unavailable and AllowContactingSource enabled in a ImageTagMirrorSet", func() {
 			var err error
@@ -1742,7 +1743,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet,
 			), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should not set node affinity when source registry is working, mirrors are unavailable and NeverContactingSource enabled in a ImageTagMirrorSet", func() {
 			var err error
@@ -1825,7 +1826,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should set node affinity when image has digest and port", func() {
 			var err error
@@ -1874,7 +1875,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should set node affinity when image has tag and port", func() {
 			var err error
@@ -1923,7 +1924,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 		It("Should set node affinity when image has digest and tag and port", func() {
 			var err error
@@ -1972,7 +1973,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test",
 				defaultExpectedAffinityTerms()), e2e.WaitShort).Should(Succeed())
 			By("The pod should be running")
-			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
+			Eventually(framework.VerifyPodsAreRunning(ctx, client, ns, "app", "test"), e2e.WaitMedium).Should(Succeed())
 		})
 	})
 	Context("the Preferred Node Affinity is correctly set with PodPlacementConfigs", func() {
@@ -1983,7 +1984,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Expect(err).NotTo(HaveOccurred())
 			//nolint:errcheck
 			defer client.Delete(ctx, ns)
-			By("Creating a PodPlacementConfig")
+			By("Creating PodPlacementConfigs")
 			ppc1 := NewPodPlacementConfig().
 				WithName("test-ppc1").
 				WithNamespace(ns.Name).
@@ -2000,7 +2001,6 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithNodeAffinityScoringTerm(utils.ArchitectureS390x, 10).
 				Build()
 			Expect(client.Create(ctx, ppc2)).To(Succeed())
-			By("Creating a PodPlacementConfig")
 			ppc3 := NewPodPlacementConfig().
 				WithName("test-ppc3").
 				WithNamespace(ns.Name).
@@ -2010,6 +2010,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithNodeAffinityScoringTerm(utils.ArchitecturePpc64le, 40).
 				Build()
 			Expect(client.Create(ctx, ppc3)).To(Succeed())
+			By("Waiting for all PodPlacementConfigs to be available")
+			Eventually(func(g Gomega) {
+				ppcList := &v1beta1.PodPlacementConfigList{}
+				err := client.List(ctx, ppcList, runtimeclient.InNamespace(ns.Name))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ppcList.Items).To(HaveLen(3))
+			}).Should(Succeed())
 			By("Creating a matching deployment")
 			ps := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).
@@ -2064,6 +2071,12 @@ var _ = Describe("The Pod Placement Operand", func() {
 				}).
 				Build()
 			Expect(client.Create(ctx, ppc)).To(Succeed())
+			By("Waiting for the PodPlacementConfig to be available")
+			Eventually(func(g Gomega) {
+				p := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, runtimeclient.ObjectKey{Name: "test-ppc-backend", Namespace: ns.Name}, p)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
 			By("Creating a backend deployment that matches the selector")
 			backendPs := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).
@@ -2141,6 +2154,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 30).
 				Build()
 			Expect(client.Create(ctx, ppcHigh)).To(Succeed())
+			By("Waiting for all PodPlacementConfigs to be available")
+			Eventually(func(g Gomega) {
+				ppcList := &v1beta1.PodPlacementConfigList{}
+				err := client.List(ctx, ppcList, runtimeclient.InNamespace(ns.Name))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ppcList.Items).To(HaveLen(2))
+			}).Should(Succeed())
 			By("Creating a matching deployment")
 			ps := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).
@@ -2201,6 +2221,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithNodeAffinityScoringTerm(utils.ArchitecturePpc64le, 40).
 				Build()
 			Expect(client.Create(ctx, ppcLow)).To(Succeed())
+			By("Waiting for all PodPlacementConfigs to be available")
+			Eventually(func(g Gomega) {
+				ppcList := &v1beta1.PodPlacementConfigList{}
+				err := client.List(ctx, ppcList, runtimeclient.InNamespace(ns.Name))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ppcList.Items).To(HaveLen(2))
+			}).Should(Succeed())
 			By("Creating a matching deployment")
 			ps := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).
@@ -2255,6 +2282,12 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 20).
 				Build()
 			Expect(client.Create(ctx, ppc)).To(Succeed())
+			By("Waiting for the PodPlacementConfig to be available")
+			Eventually(func(g Gomega) {
+				p := &v1beta1.PodPlacementConfig{}
+				err = client.Get(ctx, runtimeclient.ObjectKey{Name: "test-ppc-conflict", Namespace: ns.Name}, p)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
 			By("Creating a deployment with user-defined preferred node affinity for amd64")
 			archLabelPST := NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(5).Build()
 			ps := NewPodSpec().


### PR DESCRIPTION
  Problem

  E2e tests are failing intermittently across multiple OCP versions due to five distinct issues:

  1. PPC cache race condition — Tests create a PodPlacementConfig then immediately create a deployment. The pod reconciler reads PPCs from the controller-runtime informer cache (pod_reconciler.go:111), which may not have
  synced the new PPC yet. Once the pod is processed without PPC preferred affinity and the scheduling gate is removed, it won't be reprocessed — the preferred affinity is permanently missed.
  2. Insufficient timeout for pod running checks — ICSP/mirror registry tests assert VerifyPodsAreRunning with WaitShort (1 minute). After scheduling gate removal, pods need to be scheduled, pull images through mirror fallback
  chains, and start. If a pod fails and the Deployment controller creates a replacement (which gets re-gated), 1 minute is not enough for the full cycle to converge.
  3. eNoExecEvent cleanup deadlock — When a CPPC is deleted, handleEnoexecDelete() deletes the enoexec-controller Deployment in the first phase alongside the DaemonSet, then expects the handler to process remaining non-errored
  ENoExecEvent CRs. Since the handler is already killed, non-errored events never get processed, and the CPPC stays stuck in "Deleting" state with its finalizer never removed. This causes cascading 409 Conflict failures in
  subsequent Serial tests.
  4. eNoExecEvent daemon status update race — The daemon's processEvent() creates an ENoExecEvent CR then updates its status subresource in a separate call. Between these two operations, the handler controller reconciles the
  CR, sees Status.PodName == "" (not set yet), and calls markAsError() which changes the resourceVersion. The daemon's Status().Update() then fails with a conflict error and rolls back by deleting the CR. This happens on every
  single event — the ExecFormatError monitoring feature is completely non-functional.
  5. ServiceMonitor scheme case mismatch — The vendored prometheus-operator v0.91.0 changed the SchemeHTTPS constant from "https" to "HTTPS", but the ServiceMonitor CRD validation on OCP 4.20+ requires lowercase. This causes
  the operator reconciler to loop forever with Unsupported value: "HTTPS", preventing the CPPC from ever reaching Available state.
  reaching Available state.

  Fix

  1. PPC cache race — Add Eventually + Get/List waits after PPC creation before creating deployments in 8 affected tests across pod_placement_config_test.go and pod_placement_test.go.
  2. Pod running timeout — Increase VerifyPodsAreRunning timeout from WaitShort (1m) to WaitMedium (3m) for 8 mirror/ICSP/image-format tests.
  3. eNoExecEvent cleanup deadlock — Move enoexec-controller Deployment deletion from phase 1 to phase 2 of handleEnoexecDelete(). The DaemonSet is deleted first (stops creating new events), but the handler deployment stays alive so it can finish processing remaining events. Also adds client.IgnoreNotFound to
  deleteErroredENoExecEvents to handle concurrent deletion by the handler.
  4. eNoExecEvent daemon race — Use the object returned by Create() directly for the first status update attempt (instead of a separate Get that opens a race window). On conflict errors, retry up to 3 times with a fresh Get before each retry.
  5. ServiceMonitor scheme — Use lowercase literal "https" instead of the monitoringv1.SchemeHTTPS constant.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PodPlacementConfig–driven scheduling by re-queuing gated pods when PodPlacementConfig objects change.
  * Strengthened ENOExecEvent cleanup to avoid errors during cleanup when resources are already gone.
  * Enhanced ENOExecEvent status writing with conflict-aware retries and rollback on failure.
* **Tests**
  * Updated and hardened pod-placement e2e tests with readiness/presence polling and stronger timing for mirror scenarios.
  * Expanded automated tests for ENOExecEvent processing, covering success, retry, exhaustion, and non-retry failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->