### PR TITLE
chore: add lgtm/approved labels to Konflux nudge PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,19 @@
       "constraints": {
         "go": "<1.26"
       }
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["bundle.konflux.Dockerfile"],
+      "matchUpdateTypes": ["digest"],
+      "addLabels": [
+        "approved",
+        "lgtm"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "rebase",
+      "platformAutomerge": true
     }
   ],
   "pruneBranchAfterAutomerge": true,


### PR DESCRIPTION
Add a packageRule to auto-label Konflux nudge PRs (digest updates to bundle.konflux.Dockerfile) with approved and lgtm, matching the existing gomod and tekton automerge configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build automation configuration to enhance Dockerfile dependency update handling, including automated approval and merge processes for faster integration of image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->