### PR TITLE
fix: use full git clone for [clean-version] detection

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -125,6 +125,8 @@ spec:
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
+    - name: depth
+      value: "0"
     - name: ociStorage
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -135,6 +135,8 @@ spec:
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
+    - name: depth
+      value: "0"
     - name: ociStorage
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter


### PR DESCRIPTION
  Problem

  The [clean-version] detection logic merged in #378 relies on git history operations:
  - git log HEAD^1..HEAD to scan all commits within a merge
  - git describe --tags to find the latest release tag
  - git log --grep='[clean-version]' $TAG..$REV to search commit ancestry

  However, the git-clone-oci-ta task defaults to depth: 1 (shallow clone). With only the HEAD commit available, HEAD^1..HEAD fails silently and the script falls back to git log -1, which only sees the merge
  commit message — missing the nudge markers and [clean-version] from inner PR commits.

  This was confirmed in snapshot multiarch-tuning-operator-v1-x-20260629-165049-000, where the run-script logs show:
  Generated commit-based version: 1.3.1+ed8a553
  instead of the expected clean 1.3.1.

  Fix

  Set depth: "0" (full clone) on the clone-repository task in both multi-arch-build-pipeline.yaml and single-arch-build-pipeline.yaml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build pipelines to explicitly clone repositories with full history (by setting clone depth to `0`) for more consistent builds.
  * Aligned the clone behavior across both single-arch and multi-arch build pipelines to keep build results uniform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->