### PR TITLE
Remove bundle.konflux.Dockerfile from operator push CEL filter

### DIFF
--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -9,8 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "v1.x" && (".tekton/***".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged()
       || "pkg/***".pathChanged() || "test/***".pathChanged() || "konflux.Dockerfile".pathChanged()
-      || "go.mod".pathChanged() || "cmd/***".pathChanged() || "go.sum".pathChanged() || "bundle/***".pathChanged() ||
-      "bundle.konflux.Dockerfile".pathChanged() || "trigger-konflux-builds.txt".pathChanged() )
+      || "go.mod".pathChanged() || "cmd/***".pathChanged() || "go.sum".pathChanged() || "bundle/***".pathChanged()
+      || "trigger-konflux-builds.txt".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: multiarch-tuning-operator-v1-x

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,5 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
-ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:3dc42fbfa385218005bcb55becedceb166d304d34e383567c27cd99c5bd29d31
+ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:0762dfd1d8d66bc1d7c43903c427cba95c9e1d24dbf28c370c95cfe38273bef8
 ARG ORIGINAL_IMG=registry.ci.openshift.org/origin/multiarch-tuning-operator:v1.x
 WORKDIR /code
 COPY ./ ./


### PR DESCRIPTION
This path in the CEL expression creates a feedback loop: nudge PRs update bundle.konflux.Dockerfile, which triggers a new operator build, producing a new digest, which triggers another nudge PR — indefinitely.