### PR TITLE
Fix update-graph version checks to scope to channel section only

### DIFF
--- a/.tekton/fbc-update-final-pipeline.yaml
+++ b/.tekton/fbc-update-final-pipeline.yaml
@@ -197,9 +197,20 @@ spec:
 
               echo "Checking if version $ENTRY_NAME exists in channel graph..."
 
-              # Check if version exists in channel entries (entries with schema: olm.channel)
-              # These are the upgrade graph entries, not the bundle metadata
-              if grep -A 10 "schema: olm.channel" fbc-v*/catalog/multiarch-tuning-operator/index.yaml | grep -q "name: $ENTRY_NAME"; then
+              # Check if version exists in channel entries (not bundle metadata)
+              VERSION_IN_CHANNEL=false
+              for check_file in fbc-v*/catalog/multiarch-tuning-operator/index.yaml; do
+                  if awk '
+                    /^schema: olm.channel$/ { in_channel=1; next }
+                    (/^schema: / || /^---$/) && in_channel { exit }
+                    in_channel { print }
+                  ' "$check_file" | grep -q "name: $ENTRY_NAME\$"; then
+                      VERSION_IN_CHANNEL=true
+                      break
+                  fi
+              done
+
+              if [ "$VERSION_IN_CHANNEL" = true ]; then
                 echo "✅ Version $ENTRY_NAME already exists in channel graph"
                 echo "This version has already been released - skipping all FBC updates"
                 touch /workspace/skip-all-updates
@@ -253,37 +264,18 @@ spec:
                 echo "Removing from $catalog_file..."
                 temp_file=$(mktemp)
 
-                # Remove the bundle entry block (from '---' or 'schema: olm.bundle' to next schema)
+                # Remove the bundle block containing the matching name.
+                # Blocks are ---delimited; buffer each block and skip if it
+                # contains the target bundle name.
                 awk -v bundle="$BUNDLE_NAME" '
-                BEGIN { in_bundle = 0; skip_lines = 0 }
+                BEGIN { buf = ""; skip = 0 }
                 /^---$/ {
-                  if (in_bundle) {
-                    in_bundle = 0
-                    next
-                  }
-                  print
-                  next
+                  if (!skip && buf != "") { printf "%s", buf }
+                  buf = $0 "\n"; skip = 0; next
                 }
-                /^schema: olm\.bundle$/ {
-                  getline
-                  if ($0 == "name: " bundle) {
-                    in_bundle = 1
-                    skip_lines = 1
-                    next
-                  } else {
-                    print "schema: olm.bundle"
-                    print
-                  }
-                  next
-                }
-                /^schema: / {
-                  if (in_bundle) {
-                    in_bundle = 0
-                  }
-                  print
-                  next
-                }
-                !in_bundle { print }
+                { buf = buf $0 "\n" }
+                $0 == "name: " bundle { skip = 1 }
+                END { if (!skip && buf != "") printf "%s", buf }
                 ' "$catalog_file" > "$temp_file"
 
                 mv "$temp_file" "$catalog_file"
@@ -398,6 +390,15 @@ spec:
               jq --version
               yq --version
 
+              # Helper: extract only the olm.channel section from an index.yaml
+              extract_channel_section() {
+                awk '
+                  /^schema: olm.channel$/ { in_channel=1; next }
+                  (/^schema: / || /^---$/) && in_channel { exit }
+                  in_channel { print }
+                ' "$1"
+              }
+
               # Extract base version and determine if this is a clean or commit-based version
               if [[ "$VERSION_NO_V" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\+(.+)$ ]]; then
                   BASE_VERSION="${BASH_REMATCH[1]}"
@@ -423,10 +424,10 @@ spec:
                   echo "Will replace latest version from previous base"
                   USE_SKIPS=false
 
-                  # Check if this clean version already exists
+                  # Check if this clean version already exists in channel graph (not bundle entries)
                   for check_file in fbc-v*/catalog/multiarch-tuning-operator/index.yaml; do
-                      if grep -q "name: multiarch-tuning-operator.v${BASE_VERSION}\$" "$check_file"; then
-                          echo "ERROR: Clean version $BASE_VERSION already exists in catalog"
+                      if extract_channel_section "$check_file" | grep -q "name: multiarch-tuning-operator.v${BASE_VERSION}\$"; then
+                          echo "ERROR: Clean version $BASE_VERSION already exists in channel graph"
                           echo "Cannot add duplicate clean version"
                           exit 1
                       fi
@@ -441,17 +442,17 @@ spec:
 
                   echo "Patch version - adds to existing base $BASE_VERSION"
 
-                  # Verify clean version exists for this base
+                  # Verify clean version exists for this base in channel graph (not bundle entries)
                   CLEAN_VERSION_EXISTS=false
                   for check_file in fbc-v*/catalog/multiarch-tuning-operator/index.yaml; do
-                      if grep -q "name: multiarch-tuning-operator.v${BASE_VERSION}\$" "$check_file"; then
+                      if extract_channel_section "$check_file" | grep -q "name: multiarch-tuning-operator.v${BASE_VERSION}\$"; then
                           CLEAN_VERSION_EXISTS=true
                           break
                       fi
                   done
 
                   if [ "$CLEAN_VERSION_EXISTS" = false ]; then
-                      echo "ERROR: Clean version $BASE_VERSION does not exist in catalog"
+                      echo "ERROR: Clean version $BASE_VERSION does not exist in channel graph"
                       echo "Cannot add patch versions before the clean version is released"
                       echo "Release pattern: clean version FIRST (1.4.0), then patches (1.4.0+abc, 1.4.0+def)"
                       exit 1
@@ -468,7 +469,7 @@ spec:
                   if [ "$IS_CLEAN_VERSION" = false ]; then
                       # Check if other patches exist in this specific catalog file's channel section
                       # Extract only the channel entries section to avoid matching bundle entries added by BUILD-INDEXES
-                      CHANNEL_PATCHES=$(awk '/^schema: olm.channel$/,/^schema:/ {print}' "$index_file" | \
+                      CHANNEL_PATCHES=$(extract_channel_section "$index_file" | \
                           grep "name: multiarch-tuning-operator.v${BASE_VERSION}+" || true)
 
                       if [ -n "$CHANNEL_PATCHES" ]; then
@@ -493,7 +494,8 @@ spec:
                       # Clean versions are permanent milestones that cannot be skipped
                       # File order is insertion order (newest first)
                       # Exclude the version we're currently adding
-                      ALL_PATCHES=$(grep "name: multiarch-tuning-operator.v${BASE_VERSION}+" "$index_file" | \
+                      ALL_PATCHES=$(extract_channel_section "$index_file" | \
+                          grep "name: multiarch-tuning-operator.v${BASE_VERSION}+" | \
                           sed 's/.*name: //' | sed 's/^[[:space:]]*//' | \
                           grep -v "^${ENTRY_NAME}$" || true)
 
@@ -531,7 +533,7 @@ spec:
                                 inserted = 1
                               }
                               /^schema: olm.channel$/ { in_channel = 1 }
-                              /^schema: / && !/^schema: olm.channel$/ { in_channel = 0 }
+                              (/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
                               { print }
                               ' "$index_file" > "$temp_file"
                           else
@@ -545,7 +547,7 @@ spec:
                                 inserted = 1
                               }
                               /^schema: olm.channel$/ { in_channel = 1 }
-                              /^schema: / && !/^schema: olm.channel$/ { in_channel = 0 }
+                              (/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
                               { print }
                               ' "$index_file" > "$temp_file"
                           fi
@@ -561,7 +563,7 @@ spec:
 
                       if [ "$IS_CLEAN_VERSION" = true ]; then
                           # Clean version - replaces latest version overall (from any base)
-                          PREV_VERSION=$(grep -A 5 "schema: olm.channel" "$index_file" | \
+                          PREV_VERSION=$(extract_channel_section "$index_file" | \
                               grep "name: multiarch-tuning-operator.v" | head -1 | \
                               sed 's/.*name: multiarch-tuning-operator.v//' | sed 's/^[[:space:]]*//' || true)
 
@@ -576,7 +578,7 @@ spec:
                                 inserted = 1
                               }
                               /^schema: olm.channel$/ { in_channel = 1 }
-                              /^schema: / && !/^schema: olm.channel$/ { in_channel = 0 }
+                              (/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
                               { print }
                               ' "$index_file" > "$temp_file"
                           else
@@ -589,7 +591,7 @@ spec:
                                 inserted = 1
                               }
                               /^schema: olm.channel$/ { in_channel = 1 }
-                              /^schema: / && !/^schema: olm.channel$/ { in_channel = 0 }
+                              (/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
                               { print }
                               ' "$index_file" > "$temp_file"
                           fi
@@ -605,7 +607,7 @@ spec:
                             inserted = 1
                           }
                           /^schema: olm.channel$/ { in_channel = 1 }
-                          /^schema: / && !/^schema: olm.channel$/ { in_channel = 0 }
+                          (/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
                           { print }
                           ' "$index_file" > "$temp_file"
                       fi
@@ -767,9 +769,11 @@ spec:
               git config user.name "Konflux Release Bot"
               git config user.email "konflux-release@redhat.com"
 
-              # Configure git authentication
+              # Configure git authentication using the pipeline's GIT_URL parameter
+              GIT_URL="$(params.GIT_URL)"
+              [[ "$GIT_URL" == *.git ]] || GIT_URL="${GIT_URL}.git"
               echo "Configuring GitHub authentication..."
-              git remote set-url origin "https://oauth2:${GITHUB_TOKEN}@github.com/openshift/multiarch-tuning-operator.git"
+              git remote set-url origin "https://oauth2:${GITHUB_TOKEN}@${GIT_URL#https://}"
 
               # Use consistent branch name for all FBC updates
               PR_BRANCH="auto-fbc-update"

--- a/.tekton/tag-release-commit-pipeline.yaml
+++ b/.tekton/tag-release-commit-pipeline.yaml
@@ -104,10 +104,10 @@ spec:
         - extract-release-commit
       taskSpec:
         params:
-          - name: release-name
+          - name: snapshot
         results:
           - name: VERSION
-            description: Version extracted from release name
+            description: Version extracted from bundle CSV
         steps:
           - name: parse-version
             image: quay.io/konflux-ci/appstudio-utils:latest
@@ -115,26 +115,84 @@ spec:
               #!/bin/bash
               set -euo pipefail
 
-              RELEASE_NAME='$(params.release-name)'
+              # Install tools
+              mkdir -p /tmp/tools
+              export PATH="/tmp/tools:$PATH"
 
-              # Extract version from release name (e.g., release-test-1-3-0-xyz -> v1.3.0)
-              VERSION=$(echo "$RELEASE_NAME" | grep -oP '\d+-\d+-\d+' | tr '-' '.' | sed 's/^/v/')
+              if ! command -v jq &> /dev/null; then
+                JQ_VERSION=$(curl -s https://api.github.com/repos/jqlang/jq/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+                curl -sL "https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-linux-amd64" -o /tmp/tools/jq
+                chmod +x /tmp/tools/jq
+              fi
 
-              if [ -z "$VERSION" ] || [ "$VERSION" = "v" ]; then
-                echo "❌ ERROR: Unable to extract version from release name: $RELEASE_NAME"
-                echo "   Expected format: release-X-Y-Z-suffix"
+              curl -sL "https://github.com/lework/skopeo-binary/releases/download/v1.17.0/skopeo-linux-amd64" -o /tmp/tools/skopeo
+              chmod +x /tmp/tools/skopeo
+
+              YQ_VERSION=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+              curl -sL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /tmp/tools/yq
+              chmod +x /tmp/tools/yq
+
+              # Fetch snapshot
+              SNAPSHOT_REF='$(params.snapshot)'
+              if [[ "$SNAPSHOT_REF" == *"/"* ]]; then
+                SNAPSHOT_NAMESPACE="${SNAPSHOT_REF%/*}"
+                SNAPSHOT_NAME="${SNAPSHOT_REF#*/}"
+              else
+                SNAPSHOT_NAMESPACE="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+                SNAPSHOT_NAME="$SNAPSHOT_REF"
+              fi
+
+              echo "Fetching snapshot $SNAPSHOT_NAME from namespace $SNAPSHOT_NAMESPACE..."
+              SNAPSHOT=$(oc get snapshot "$SNAPSHOT_NAME" -n "$SNAPSHOT_NAMESPACE" -o json)
+
+              # Extract bundle image from snapshot
+              BUNDLE_IMAGE=$(echo "$SNAPSHOT" | jq -r '.spec.components[] | select(.name | contains("bundle")) | .containerImage' | head -n1)
+              if [ -z "$BUNDLE_IMAGE" ] || [ "$BUNDLE_IMAGE" = "null" ]; then
+                echo "❌ ERROR: No bundle image found in snapshot"
+                exit 1
+              fi
+              echo "Bundle image: $BUNDLE_IMAGE"
+
+              # Copy and extract bundle to get CSV
+              BUNDLE_DIR="/tmp/bundle"
+              LAYERS_DIR="/tmp/bundle-extracted"
+              mkdir -p "$BUNDLE_DIR" "$LAYERS_DIR"
+
+              skopeo copy "docker://$BUNDLE_IMAGE" "dir:$BUNDLE_DIR"
+
+              MANIFEST_FILE=$(find "$BUNDLE_DIR" -name "manifest.json" | head -1)
+              if [ -z "$MANIFEST_FILE" ]; then
+                echo "❌ ERROR: Could not find manifest.json in bundle image"
                 exit 1
               fi
 
-              # Append test suffix with timestamp to avoid conflicts
-              TIMESTAMP=$(date +%s)
-              VERSION="${VERSION}-test-${TIMESTAMP}"
+              for layer in $(jq -r '.layers[].digest' "$MANIFEST_FILE" | cut -d: -f2); do
+                if [ -f "$BUNDLE_DIR/$layer" ]; then
+                  tar -xzf "$BUNDLE_DIR/$layer" -C "$LAYERS_DIR" 2>/dev/null || \
+                  tar -xf "$BUNDLE_DIR/$layer" -C "$LAYERS_DIR" 2>/dev/null || true
+                fi
+              done
 
-              echo "Extracted version: $VERSION"
+              CSV_FILE=$(find "$LAYERS_DIR" -name "*clusterserviceversion.yaml" | head -1)
+              if [ -z "$CSV_FILE" ]; then
+                echo "❌ ERROR: Could not find CSV file in bundle"
+                exit 1
+              fi
+
+              # Extract version from CSV
+              VERSION=$(yq eval '.spec.version' "$CSV_FILE")
+              if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+                echo "❌ ERROR: Could not extract version from CSV"
+                exit 1
+              fi
+
+              [[ "$VERSION" =~ ^v ]] || VERSION="v${VERSION}"
+
+              echo "Extracted version from bundle CSV: $VERSION"
               echo -n "$VERSION" > $(results.VERSION.path)
       params:
-        - name: release-name
-          value: $(tasks.extract-release-commit.results.RELEASE_NAME)
+        - name: snapshot
+          value: $(params.snapshot)
 
     - name: tag-release-commit
       runAfter:
@@ -246,6 +304,39 @@ spec:
                 GITHUB_TOKEN=""
               fi
 
+              # Derive authenticated URL from GIT_URL parameter
+              AUTH_GIT_URL="$GIT_URL"
+              [[ "$AUTH_GIT_URL" == *.git ]] || AUTH_GIT_URL="${AUTH_GIT_URL}.git"
+
+              # Check if tag already exists on the remote before cloning
+              echo "Checking if tag $VERSION already exists on remote..."
+              if [ -n "${GITHUB_TOKEN:-}" ]; then
+                REMOTE_CHECK_URL="https://oauth2:${GITHUB_TOKEN}@${AUTH_GIT_URL#https://}"
+              else
+                REMOTE_CHECK_URL="$GIT_URL"
+              fi
+
+              # Fetch both the tag ref and its peeled commit (^{})
+              TAG_REFS=$(git ls-remote --tags "$REMOTE_CHECK_URL" "refs/tags/$VERSION" "refs/tags/$VERSION^{}" 2>/dev/null)
+              EXISTING_TAG_SHA=$(echo "$TAG_REFS" | awk -v tag="refs/tags/$VERSION" '$2 == tag {print $1}')
+
+              if [ -n "$EXISTING_TAG_SHA" ]; then
+                # Resolve peeled commit (for annotated tags); fall back to tag SHA for lightweight tags
+                PEELED_SHA=$(echo "$TAG_REFS" | awk -v tag="refs/tags/$VERSION^{}" '$2 == tag {print $1}')
+                TAG_COMMIT="${PEELED_SHA:-$EXISTING_TAG_SHA}"
+
+                if [ "$TAG_COMMIT" = "$COMMIT_SHA" ]; then
+                  echo "✅ Tag $VERSION already exists on remote pointing to correct commit ($COMMIT_SHA)"
+                  echo -n "$VERSION" > $(results.TAG_NAME.path)
+                  exit 0
+                else
+                  echo "⚠️  Tag $VERSION exists on remote but points to $TAG_COMMIT, not $COMMIT_SHA"
+                  echo "Proceeding to clone and verify..."
+                fi
+              else
+                echo "Tag $VERSION does not exist on remote — will create it."
+              fi
+
               # Clone the repository
               REPO_DIR="/tmp/repo"
               echo "Cloning repository (branch: $GIT_BRANCH)..."
@@ -253,7 +344,7 @@ spec:
               if [ -n "${GITHUB_TOKEN:-}" ]; then
                 echo "Using authenticated clone..."
                 git clone --branch "$GIT_BRANCH" --single-branch \
-                  "https://oauth2:${GITHUB_TOKEN}@github.com/openshift/multiarch-tuning-operator.git" \
+                  "https://oauth2:${GITHUB_TOKEN}@${AUTH_GIT_URL#https://}" \
                   "$REPO_DIR"
               else
                 echo "⚠️  Warning: GITHUB_TOKEN not set, cloning without authentication..."
@@ -270,7 +361,7 @@ spec:
 
               # Configure authentication for push if token available
               if [ -n "${GITHUB_TOKEN:-}" ]; then
-                git remote set-url origin "https://oauth2:${GITHUB_TOKEN}@github.com/openshift/multiarch-tuning-operator.git"
+                git remote set-url origin "https://oauth2:${GITHUB_TOKEN}@${AUTH_GIT_URL#https://}"
               fi
 
               # Check if tag already exists

--- a/.tekton/tests/test-pipeline-scripts.sh
+++ b/.tekton/tests/test-pipeline-scripts.sh
@@ -1,0 +1,404 @@
+#!/bin/bash
+# Tests for fbc-update-final-pipeline.yaml and tag-release-commit-pipeline.yaml
+# Validates the shell script logic embedded in the Tekton pipeline steps.
+#
+# Prerequisites:
+#   - git remote 'downstream' pointing at openshift/multiarch-tuning-operator
+#   - downstream/fbc branch fetched (git fetch downstream fbc)
+#
+# Usage: bash .tekton/tests/test-pipeline-scripts.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PIPELINE_FILE="$REPO_ROOT/.tekton/fbc-update-final-pipeline.yaml"
+TAG_PIPELINE_FILE="$REPO_ROOT/.tekton/tag-release-commit-pipeline.yaml"
+
+# Create a temp directory for test fixtures
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+pass() { ((PASS++)); echo "  PASS: $1"; }
+fail() { ((FAIL++)); echo "  FAIL: $1"; }
+
+# ── Setup: extract real FBC index.yaml for testing ──────────────────────
+echo "Setting up test fixtures..."
+git show downstream/fbc:fbc-v4-16/catalog/multiarch-tuning-operator/index.yaml > "$TMPDIR/index-v4-16.yaml" 2>/dev/null || {
+    echo "ERROR: Cannot fetch downstream/fbc branch. Run: git fetch downstream fbc"
+    exit 1
+}
+git show downstream/fbc:fbc-v4-17/catalog/multiarch-tuning-operator/index.yaml > "$TMPDIR/index-v4-17.yaml" 2>/dev/null
+
+# ═══════════════════════════════════════════════════════════════════════
+# FBC UPDATE FINAL PIPELINE TESTS
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo " FBC Update Final Pipeline Tests"
+echo "═══════════════════════════════════════════════════════════════"
+
+# ── Test: awk channel extractor only returns channel section ─────────
+echo ""
+echo "── Channel extractor ──"
+
+CHANNEL_OUTPUT=$(awk '
+  /^schema: olm.channel$/ { in_channel=1; next }
+  (/^schema: / || /^---$/) && in_channel { exit }
+  in_channel { print }
+' "$TMPDIR/index-v4-16.yaml")
+
+# Should contain channel entries
+if echo "$CHANNEL_OUTPUT" | grep -q "name: multiarch-tuning-operator.v"; then
+    pass "Channel extractor finds version entries"
+else
+    fail "Channel extractor finds version entries"
+fi
+
+# Should NOT contain bundle data (image: lines)
+if echo "$CHANNEL_OUTPUT" | grep -q "^image:"; then
+    fail "Channel extractor excludes bundle image: lines"
+else
+    pass "Channel extractor excludes bundle image: lines"
+fi
+
+# Should NOT contain schema: olm.bundle
+if echo "$CHANNEL_OUTPUT" | grep -q "schema: olm.bundle"; then
+    fail "Channel extractor excludes schema: olm.bundle"
+else
+    pass "Channel extractor excludes schema: olm.bundle"
+fi
+
+# Should contain entries: keyword
+if echo "$CHANNEL_OUTPUT" | grep -q "^entries:"; then
+    pass "Channel extractor includes entries: keyword"
+else
+    fail "Channel extractor includes entries: keyword"
+fi
+
+# Count: should find ALL channel entries (currently 7)
+ENTRY_COUNT=$(echo "$CHANNEL_OUTPUT" | grep -c "name: multiarch-tuning-operator.v" || true)
+if [ "$ENTRY_COUNT" -ge 7 ]; then
+    pass "Channel extractor finds all $ENTRY_COUNT entries (>= 7)"
+else
+    fail "Channel extractor finds all entries (got $ENTRY_COUNT, expected >= 7)"
+fi
+
+# Works the same on v4-17 format
+CHANNEL_OUTPUT_17=$(awk '
+  /^schema: olm.channel$/ { in_channel=1; next }
+  (/^schema: / || /^---$/) && in_channel { exit }
+  in_channel { print }
+' "$TMPDIR/index-v4-17.yaml")
+
+ENTRY_COUNT_17=$(echo "$CHANNEL_OUTPUT_17" | grep -c "name: multiarch-tuning-operator.v" || true)
+if [ "$ENTRY_COUNT" -eq "$ENTRY_COUNT_17" ]; then
+    pass "Channel extractor consistent between v4-16 and v4-17 ($ENTRY_COUNT entries)"
+else
+    fail "Channel extractor inconsistent: v4-16=$ENTRY_COUNT, v4-17=$ENTRY_COUNT_17"
+fi
+
+# ── Test: channel extractor version matching ─────────────────────────
+echo ""
+echo "── Version matching in channel ──"
+
+# Existing version should be found
+if echo "$CHANNEL_OUTPUT" | grep -q "name: multiarch-tuning-operator.v1.3.0$"; then
+    pass "Finds existing version v1.3.0 in channel"
+else
+    fail "Finds existing version v1.3.0 in channel"
+fi
+
+# Non-existent version should NOT be found
+if echo "$CHANNEL_OUTPUT" | grep -q "name: multiarch-tuning-operator.v9.9.9$"; then
+    fail "Rejects non-existent version v9.9.9"
+else
+    pass "Rejects non-existent version v9.9.9"
+fi
+
+# Partial version match should not match (v1.3.0 should not match v1.3.0+abc)
+if echo "$CHANNEL_OUTPUT" | grep -q "name: multiarch-tuning-operator.v1.3.0+"; then
+    fail "Does not false-match patch version v1.3.0+"
+else
+    pass "Does not false-match patch version v1.3.0+"
+fi
+
+# ── Test: bundle block removal ───────────────────────────────────────
+echo ""
+echo "── Bundle block removal ──"
+
+# Create test fixture with multiple blocks
+cat > "$TMPDIR/test-removal.yaml" << 'FIXTURE'
+---
+defaultChannel: stable
+name: test-operator
+schema: olm.package
+---
+schema: olm.channel
+name: stable
+entries:
+  - name: test-operator.v1.0.0
+  - name: test-operator.v1.1.0
+---
+image: quay.io/test@sha256:aaa
+name: test-operator.v1.0.0
+package: test-operator
+properties:
+  - type: olm.package
+    value:
+      packageName: test-operator
+      version: 1.0.0
+schema: olm.bundle
+---
+image: quay.io/test@sha256:bbb
+name: test-operator.v1.1.0
+package: test-operator
+properties:
+  - type: olm.package
+    value:
+      packageName: test-operator
+      version: 1.1.0
+schema: olm.bundle
+FIXTURE
+
+# Helper: remove a bundle block by name from an index.yaml
+remove_bundle() {
+  awk -v bundle="$2" '
+  BEGIN { buf = ""; skip = 0 }
+  /^---$/ {
+    if (!skip && buf != "") { printf "%s", buf }
+    buf = $0 "\n"; skip = 0; next
+  }
+  { buf = buf $0 "\n" }
+  $0 == "name: " bundle { skip = 1 }
+  END { if (!skip && buf != "") printf "%s", buf }
+  ' "$1"
+}
+
+# Remove v1.0.0 bundle
+REMOVAL_OUTPUT=$(remove_bundle "$TMPDIR/test-removal.yaml" "test-operator.v1.0.0")
+
+# Should still contain v1.1.0 bundle
+if echo "$REMOVAL_OUTPUT" | grep -q "name: test-operator.v1.1.0"; then
+    pass "Bundle removal preserves non-target bundle (v1.1.0)"
+else
+    fail "Bundle removal preserves non-target bundle (v1.1.0)"
+fi
+
+# Should NOT contain v1.0.0 bundle
+if echo "$REMOVAL_OUTPUT" | grep -q "image: quay.io/test@sha256:aaa"; then
+    fail "Bundle removal removes target bundle image (v1.0.0)"
+else
+    pass "Bundle removal removes target bundle image (v1.0.0)"
+fi
+
+# Should preserve channel entries (even though they reference v1.0.0)
+if echo "$REMOVAL_OUTPUT" | grep -q "name: test-operator.v1.0.0"; then
+    # Channel entry has "  - name: test-operator.v1.0.0" (indented)
+    # This is OK — we only remove the bundle block, not channel entries
+    pass "Bundle removal preserves channel entry referencing same version"
+else
+    fail "Bundle removal preserves channel entry referencing same version"
+fi
+
+# Should preserve package block
+if echo "$REMOVAL_OUTPUT" | grep -q "schema: olm.package"; then
+    pass "Bundle removal preserves olm.package block"
+else
+    fail "Bundle removal preserves olm.package block"
+fi
+
+# Should preserve channel block
+if echo "$REMOVAL_OUTPUT" | grep -q "schema: olm.channel"; then
+    pass "Bundle removal preserves olm.channel block"
+else
+    fail "Bundle removal preserves olm.channel block"
+fi
+
+# Removing non-existent bundle should preserve everything
+NOOP_OUTPUT=$(remove_bundle "$TMPDIR/test-removal.yaml" "test-operator.v9.9.9")
+
+ORIG_LINES=$(wc -l < "$TMPDIR/test-removal.yaml")
+NOOP_LINES=$(echo "$NOOP_OUTPUT" | wc -l)
+if [ "$ORIG_LINES" -eq "$NOOP_LINES" ]; then
+    pass "Bundle removal is no-op for non-existent version (line count preserved)"
+else
+    fail "Bundle removal is no-op for non-existent version (orig=$ORIG_LINES, got=$NOOP_LINES)"
+fi
+
+# ── Test: insertion awk in_channel boundary ──────────────────────────
+echo ""
+echo "── Insertion awk in_channel boundary ──"
+
+# Simulate inserting a new entry — write output to file for reliable comparison
+INSERT_FILE="$TMPDIR/insert-output.yaml"
+awk -v entry="multiarch-tuning-operator.v1.4.0" -v prev="1.3.0" '
+/^  - name: / && !inserted && in_channel {
+  print "  - name: " entry
+  print "    replaces: multiarch-tuning-operator.v" prev
+  inserted = 1
+}
+/^schema: olm.channel$/ { in_channel = 1 }
+(/^schema: / && !/^schema: olm.channel$/) || /^---$/ { in_channel = 0 }
+{ print }
+' "$TMPDIR/index-v4-16.yaml" > "$INSERT_FILE"
+
+# Should have exactly one insertion
+INSERT_COUNT=$(grep -c "name: multiarch-tuning-operator.v1.4.0" "$INSERT_FILE" || true)
+if [ "$INSERT_COUNT" -eq 1 ]; then
+    pass "Insertion awk inserts exactly once"
+else
+    fail "Insertion awk inserts exactly once (got $INSERT_COUNT)"
+fi
+
+# New entry should come before v1.3.0
+FIRST_ENTRY=$(grep "name: multiarch-tuning-operator.v" "$INSERT_FILE" | head -1)
+if echo "$FIRST_ENTRY" | grep -q "v1.4.0"; then
+    pass "Insertion awk inserts before existing first entry"
+else
+    fail "Insertion awk inserts before existing first entry (first was: $FIRST_ENTRY)"
+fi
+
+# replaces field should be present
+if grep -q "replaces: multiarch-tuning-operator.v1.3.0" "$INSERT_FILE"; then
+    pass "Insertion awk includes replaces field"
+else
+    fail "Insertion awk includes replaces field"
+fi
+
+# Verify insertion added exactly 2 lines (normalize trailing newlines for comparison)
+ORIG_NORMALIZED="$TMPDIR/orig-normalized.yaml"
+sed -e '$a\' "$TMPDIR/index-v4-16.yaml" > "$ORIG_NORMALIZED" 2>/dev/null
+DIFF_ADDED=$(diff "$ORIG_NORMALIZED" "$INSERT_FILE" | grep "^>" | wc -l)
+if [ "$DIFF_ADDED" -eq 2 ]; then
+    pass "Insertion awk adds exactly 2 new lines (no other changes)"
+else
+    fail "Insertion awk adds exactly 2 new lines (got $DIFF_ADDED added lines)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════
+# TAG RELEASE COMMIT PIPELINE TESTS
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo " Tag Release Commit Pipeline Tests"
+echo "═══════════════════════════════════════════════════════════════"
+
+# ── Test: early tag existence check via git ls-remote ────────────────
+echo ""
+echo "── Early tag existence check ──"
+
+REMOTE_URL="https://github.com/openshift/multiarch-tuning-operator.git"
+
+# Existing tag should be detected
+EXISTING_SHA=$(git ls-remote --tags "$REMOTE_URL" "refs/tags/v1.3.0" 2>/dev/null | awk '{print $1}')
+if [ -n "$EXISTING_SHA" ]; then
+    pass "git ls-remote detects existing tag v1.3.0 (SHA: ${EXISTING_SHA:0:12})"
+else
+    fail "git ls-remote detects existing tag v1.3.0"
+fi
+
+# Non-existent tag should return empty
+NONEXIST_SHA=$(git ls-remote --tags "$REMOTE_URL" "refs/tags/v99.99.99" 2>/dev/null | awk '{print $1}')
+if [ -z "$NONEXIST_SHA" ]; then
+    pass "git ls-remote returns empty for non-existent tag v99.99.99"
+else
+    fail "git ls-remote returns empty for non-existent tag v99.99.99 (got: $NONEXIST_SHA)"
+fi
+
+# ── Test: URL parameterization ───────────────────────────────────────
+echo ""
+echo "── URL parameterization ──"
+
+# Without .git suffix
+GIT_URL="https://github.com/openshift/multiarch-tuning-operator"
+AUTH_GIT_URL="$GIT_URL"
+[[ "$AUTH_GIT_URL" == *.git ]] || AUTH_GIT_URL="${AUTH_GIT_URL}.git"
+RESULT="https://oauth2:TOKEN@${AUTH_GIT_URL#https://}"
+EXPECTED="https://oauth2:TOKEN@github.com/openshift/multiarch-tuning-operator.git"
+if [ "$RESULT" = "$EXPECTED" ]; then
+    pass "URL parameterization works without .git suffix"
+else
+    fail "URL parameterization without .git suffix (got: $RESULT)"
+fi
+
+# With .git suffix
+GIT_URL="https://github.com/openshift/multiarch-tuning-operator.git"
+AUTH_GIT_URL="$GIT_URL"
+[[ "$AUTH_GIT_URL" == *.git ]] || AUTH_GIT_URL="${AUTH_GIT_URL}.git"
+RESULT="https://oauth2:TOKEN@${AUTH_GIT_URL#https://}"
+if [ "$RESULT" = "$EXPECTED" ]; then
+    pass "URL parameterization works with .git suffix"
+else
+    fail "URL parameterization with .git suffix (got: $RESULT)"
+fi
+
+# ── Test: pipeline YAML structure ────────────────────────────────────
+echo ""
+echo "── Pipeline YAML structure ──"
+
+# No hardcoded openshift/multiarch-tuning-operator URLs remain (excluding default param values and PR body)
+HARDCODED=$(grep -n "github.com/openshift/multiarch-tuning-operator" "$TAG_PIPELINE_FILE" | \
+    grep -v "default:" | grep -v "pr create" | grep -v "^#" || true)
+if [ -z "$HARDCODED" ]; then
+    pass "No hardcoded repo URLs in tag pipeline (excluding defaults)"
+else
+    fail "Hardcoded repo URLs found in tag pipeline: $HARDCODED"
+fi
+
+# extract-version task uses snapshot param (not release-name)
+if grep -q "name: snapshot" "$TAG_PIPELINE_FILE" && ! grep -q "release-name" "$TAG_PIPELINE_FILE"; then
+    pass "extract-version uses snapshot parameter"
+else
+    fail "extract-version should use snapshot, not release-name"
+fi
+
+# No -test- suffix in version extraction
+if grep -q "\-test-" "$TAG_PIPELINE_FILE"; then
+    fail "Debug -test- suffix removed from tag pipeline"
+else
+    pass "Debug -test- suffix removed from tag pipeline"
+fi
+
+# Version comes from bundle CSV (yq eval .spec.version)
+if grep -q "yq eval.*spec.version" "$TAG_PIPELINE_FILE"; then
+    pass "Version extracted from bundle CSV via yq"
+else
+    fail "Version should be extracted from bundle CSV"
+fi
+
+# Early tag check uses git ls-remote
+if grep -q "git ls-remote --tags" "$TAG_PIPELINE_FILE"; then
+    pass "Early tag existence check uses git ls-remote"
+else
+    fail "Early tag existence check should use git ls-remote"
+fi
+
+# FBC pipeline checks
+echo ""
+HARDCODED_FBC=$(grep -n "github.com/openshift/multiarch-tuning-operator" "$PIPELINE_FILE" | \
+    grep -v "default:" | grep -v "pr create" | grep -v "^#" || true)
+if [ -z "$HARDCODED_FBC" ]; then
+    pass "No hardcoded repo URLs in FBC pipeline (excluding defaults)"
+else
+    fail "Hardcoded repo URLs found in FBC pipeline: $HARDCODED_FBC"
+fi
+
+# No grep -A patterns remain in FBC pipeline
+if grep -q "grep -A" "$PIPELINE_FILE"; then
+    fail "No grep -A patterns in FBC pipeline"
+else
+    pass "No grep -A patterns in FBC pipeline"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo " Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
The duplicate-version and clean-version-exists checks were grepping the entire index.yaml, which matched olm.bundle entries added by the prior build-indexes step. Scope both checks to the olm.channel section using awk, consistent with the patch-version check already in the script.

Make bundle to trigger nudge commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release tagging now derives the version from the provided snapshot content and uses the snapshot’s embedded bundle metadata.
  * Git remote configuration is now driven by the pipeline’s configured `git-url` parameter.

* **Bug Fixes**
  * Channel graph updates are constrained to the correct channel sections, avoiding accidental matches in other YAML regions.
  * Prior bundle entries are removed more precisely, preserving other YAML blocks.
  * Version insertion/replacement behavior now respects YAML document boundaries more reliably.

* **Tests**
  * Added automated pipeline script validations covering the updated YAML parsing and tag-handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->