### PR TITLE
MULTIARCH-6284: Update go verson to 1.26.4

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: ocp
-  tag: rhel-9-golang-1.26-openshift-4.23
+  tag: rhel-9-golang-1.26-openshift-5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/multiarch-tuning-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to the latest patch release for improved stability and consistency.
  * Updated the CI build root image tag to a newer OpenShift-compatible variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->