### PR TITLE
Manually nudge fbc-inject-lifecycle-oci-ta task to latest fix

### DIFF
--- a/.tekton/fbc-build-pipeline.yaml
+++ b/.tekton/fbc-build-pipeline.yaml
@@ -381,7 +381,7 @@ spec:
       - name: name
         value: fbc-inject-lifecycle-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:1be92a668fd429a1273dfd2046631c51ee0954209d99631614474ad6a1d02626
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:a636970f2f7ff1c8156ad92e3c6bde96ce532a3195b24cc3ed4025d7d609e6eb
     params:
     - name: DOCKERFILE
       value: $(params.dockerfile)


### PR DESCRIPTION
Error on FBC pipelines 
`Error: failed to get OCP versions: failed to determine OCP version: could not parse base image reference "${BASE_IMAGE}": invalid reference format: repository name must be lowercase
`
This new task failed to resolve ARG. Nudging to latest version for the fix 

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1785241181740599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build pipeline’s lifecycle injection component to a newer verified version.
  * No changes to application functionality, configuration, or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->