### PR TITLE
Disable go mod updates using mintmaker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,45 +4,9 @@
     "enabled": false
   },
   "gomod": {
-    "enabled": true,
-    "automerge": true,
-    "automergeType": "pr",
-    "automergeStrategy": "rebase",
-    "platformAutomerge": true,
-    "addLabels": [
-      "approved",
-      "lgtm"
-    ],
-    "schedule": [
-      "on saturday"
-    ]
+    "enabled": false
   },
-  "packageRules": [
-    {
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26.0"
-    },
-    {
-      "matchDatasources": ["go"],
-      "matchManagers": ["gomod"],
-      "constraints": {
-        "go": "<1.26"
-      }
-    },
-    {
-      "matchManagers": ["dockerfile"],
-      "matchFileNames": ["bundle.konflux.Dockerfile"],
-      "matchUpdateTypes": ["digest"],
-      "addLabels": [
-        "approved",
-        "lgtm"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "rebase",
-      "platformAutomerge": true
-    }
-  ],
+  "packageRules": [],
   "pruneBranchAfterAutomerge": true,
   "pruneStaleBranches": true,
   "semanticCommits": "enabled",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings.
  * Disabled Dockerfile and Go module update managers.
  * Removed existing package-specific automation rules while preserving Tekton configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->