### PR TITLE
MULTIARCH-6270: enoexec-event-daemon DaemonSet fails to start in kustomize deployments due to ServiceAccount pull secret race condition

### DIFF
--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -763,6 +764,42 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 		_ = r.ClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, utils.PodMutatingWebhookConfigurationName, metav1.DeleteOptions{})
 	}
 
+	// Defer enoexec DaemonSet until SA imagePullSecrets are provisioned by the OpenShift SA controller.
+	// This avoids a race condition where DaemonSet pods start immediately on all nodes before the SA's
+	// dockercfg secret exists, causing FailedToRetrieveImagePullSecret errors.
+	// Once the DaemonSet already exists, the SA check is skipped because the readiness gate only
+	// matters for initial creation.
+	// NOTE: The enoexec handler Deployment has a similar (but less severe) race — it is still applied
+	// in the same batch as its ServiceAccount without waiting for imagePullSecrets. This is acceptable
+	// because Deployments retry pod creation, whereas DaemonSet pods start on every node immediately.
+	// A follow-up could gate the Deployment the same way using the shared isEnoexecDaemonSetSAReady helper.
+	daemonSetDeferred := false
+	if clusterPodPlacementConfig.PluginsEnabled(common.ExecFormatErrorMonitorPluginName) {
+		logVerbosityLevel := clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()
+		includeDaemonSet := false
+		ds := &appsv1.DaemonSet{}
+		if err := r.Get(ctx, client.ObjectKey{Name: utils.EnoexecDaemonSet, Namespace: utils.Namespace()}, ds); err == nil {
+			// DaemonSet already exists; always include it so ApplyResources keeps it in sync.
+			includeDaemonSet = true
+		} else if !apierrors.IsNotFound(err) {
+			return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+		} else {
+			// DaemonSet does not exist yet; only create it once SA imagePullSecrets are provisioned.
+			saReady, err := r.isEnoexecDaemonSetSAReady(ctx)
+			if err != nil {
+				return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+			}
+			includeDaemonSet = saReady
+			if !saReady {
+				daemonSetDeferred = true
+				log.V(1).Info("Deferring enoexec DaemonSet creation: SA imagePullSecrets not yet provisioned")
+			}
+		}
+		if includeDaemonSet {
+			objects = append(objects, buildDaemonSetENoExecEvent(utils.EnoexecDaemonSet, utils.EnoexecDaemonSet, logVerbosityLevel))
+		}
+	}
+
 	// If the servicemonitors.monitoring.coreos.com CRD is available, we create the ServiceMonitor objects
 	if utils.IsResourceAvailable(ctx, r.DynamicClient, monitoringv1.SchemeGroupVersion.WithResource("servicemonitors")) {
 		log.V(1).Info("Creating ServiceMonitors")
@@ -789,6 +826,16 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 	if err := utils.ApplyResources(ctx, r.ClientSet, r.DynamicClient, r.Recorder, objects); err != nil {
 		log.Error(err, "Unable to apply resources")
 		return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+	}
+
+	if daemonSetDeferred {
+		// Status does not track enoexec DaemonSet readiness, so updateStatus alone
+		// will not requeue once pod-placement deps are Ready. Keep retrying until
+		// SA imagePullSecrets are provisioned (Owns(SA) may also wake us sooner).
+		if err := r.updateStatus(ctx, clusterPodPlacementConfig); err != nil {
+			return err
+		}
+		return newRequeueAfterError(5*time.Second, "waiting for enoexec SA imagePullSecrets before creating DaemonSet")
 	}
 
 	return r.updateStatus(ctx, clusterPodPlacementConfig)
@@ -874,8 +921,8 @@ func (r *ClusterPodPlacementConfigReconciler) buildPodPlacementConfigObjects(clu
 	return objects, nil
 }
 
-// buildENoExecEventObjects if the ExecFormatErrorMonitor plugin is enabled create the deployment to start the controller
-// if it does not already exist
+// buildENoExecEventObjects builds the ENoExecEvent plugin resources (ServiceAccounts, RBAC, Deployment, ServiceMonitors)
+// excluding the DaemonSet, which is conditionally appended in reconcile() based on SA readiness.
 func (r *ClusterPodPlacementConfigReconciler) buildENoExecEventObjects(ctx context.Context, clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) ([]client.Object, error) {
 	log := ctrllog.FromContext(ctx)
 	logVerbosityLevel := clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()
@@ -953,8 +1000,8 @@ func (r *ClusterPodPlacementConfigReconciler) buildENoExecEventObjects(ctx conte
 			},
 		),
 		buildDeploymentENoExecEventHandler(logVerbosityLevel),
-		buildDaemonSetENoExecEvent(utils.EnoexecDaemonSet, utils.EnoexecDaemonSet, logVerbosityLevel),
 	}
+
 	// If the servicemonitors.monitoring.coreos.com CRD is available, we create the ServiceMonitor objects
 	if utils.IsResourceAvailable(ctx, r.DynamicClient, monitoringv1.SchemeGroupVersion.WithResource("servicemonitors")) {
 		log.V(1).Info("Creating ServiceMonitors")
@@ -967,6 +1014,32 @@ func (r *ClusterPodPlacementConfigReconciler) buildENoExecEventObjects(ctx conte
 		log.V(1).Info("servicemonitoring.monitoring.coreos.com is not available. Skipping the creation of the ServiceMonitors")
 	}
 	return objects, nil
+}
+
+// isEnoexecDaemonSetSAReady checks whether the enoexec-event-daemon ServiceAccount exists and
+// has imagePullSecrets provisioned by the OpenShift SA controller. Returns false if the SA does
+// not exist yet or has no imagePullSecrets.
+// Uses the cached client (r.Get) instead of a live API call because the controller already
+// Owns(&corev1.ServiceAccount{}), so the SA is in the informer cache.
+//
+// NOTE: This readiness gate assumes the OpenShift SA controller will eventually populate
+// imagePullSecrets on the ServiceAccount. On plain Kubernetes or in envtest (without the
+// OpenShift SA controller), imagePullSecrets are never auto-provisioned, so the DaemonSet
+// will not be created unless the SA is manually updated — which is why the integration test
+// simulates this via simulateSAImagePullSecretProvisioning.
+func (r *ClusterPodPlacementConfigReconciler) isEnoexecDaemonSetSAReady(ctx context.Context) (bool, error) {
+	sa := &corev1.ServiceAccount{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      utils.EnoexecDaemonSet,
+		Namespace: utils.Namespace(),
+	}, sa)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(sa.ImagePullSecrets) > 0, nil
 }
 
 func isDeploymentAvailable(deployment *appsv1.Deployment) bool {

--- a/internal/controller/operator/clusterpodplacementconfig_controller_test.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller_test.go
@@ -736,6 +736,104 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 			}).Should(Succeed(), "finalizer should be removed after cleanup")
 		})
 	})
+	Context("is handling the DaemonSet creation deferral when the ServiceAccount has no imagePullSecrets", func() {
+		BeforeEach(func() {
+			By("Creating the ClusterPodPlacementConfig with ExecFormatErrorMonitor enabled")
+			err := k8sClient.Create(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).
+				WithExecFormatErrorMonitor(true).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create ClusterPodPlacementConfig", err)
+
+			By("Setting the pod placement deployments as ready")
+			for _, name := range []string{utils.PodPlacementControllerName, utils.PodPlacementWebhookName} {
+				Eventually(func(g Gomega) {
+					setDeploymentReady(name, g)
+				}).Should(Succeed(), "the deployment "+name+" should be ready")
+			}
+		})
+		AfterEach(func() {
+			By("Deleting the ClusterPodPlacementConfig")
+			err := k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+			Expect(crclient.IgnoreNotFound(err)).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+			Eventually(framework.ValidateDeletion(k8sClient, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
+		})
+		It("should defer DaemonSet creation until the ServiceAccount has imagePullSecrets", func() {
+			By("Verifying the enoexec objects WITHOUT the DaemonSet are created (SA, RBAC, Deployment)")
+			Eventually(framework.ValidateCreation(k8sClient, ctx, framework.MainPlugin,
+				framework.EnoExecPluginDeployment, framework.EnoExecPluginDeploymentObjects)).
+				Should(Succeed(), "the enoexec deployment objects should be created")
+
+			By("Verifying the enoexec-event-daemon ServiceAccount exists but has no imagePullSecrets")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, sa)
+				g.Expect(err).NotTo(HaveOccurred(), "the enoexec-event-daemon SA should be created")
+				g.Expect(sa.ImagePullSecrets).To(BeEmpty(), "the SA should have no imagePullSecrets in envtest")
+			}).Should(Succeed(), "the SA should exist without imagePullSecrets")
+
+			By("Verifying the DaemonSet is NOT created yet (SA has no imagePullSecrets in envtest)")
+			Consistently(func(g Gomega) {
+				ds := &appsv1.DaemonSet{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, ds)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "the DaemonSet should not exist yet because the SA has no imagePullSecrets")
+			}, "1s", "100ms").Should(Succeed(), "the DaemonSet should remain absent while SA has no imagePullSecrets")
+
+			By("Simulating the OpenShift SA controller provisioning imagePullSecrets")
+			simulateSAImagePullSecretProvisioning(utils.EnoexecDaemonSet)
+
+			By("Verifying the DaemonSet is created after the SA has imagePullSecrets")
+			Eventually(func(g Gomega) {
+				ds := &appsv1.DaemonSet{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, ds)
+				g.Expect(err).NotTo(HaveOccurred(), "the DaemonSet should be created after SA has imagePullSecrets")
+			}).Should(Succeed(), "the DaemonSet should be created")
+		})
+		It("should include an existing DaemonSet without checking SA imagePullSecrets", func() {
+			By("Simulating the SA controller provisioning imagePullSecrets so the DaemonSet is created initially")
+			simulateSAImagePullSecretProvisioning(utils.EnoexecDaemonSet)
+
+			By("Waiting for the DaemonSet to be created")
+			Eventually(func(g Gomega) {
+				ds := &appsv1.DaemonSet{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, ds)
+				g.Expect(err).NotTo(HaveOccurred(), "the DaemonSet should be created")
+			}).Should(Succeed(), "the DaemonSet should be created after SA has imagePullSecrets")
+
+			By("Removing imagePullSecrets from the SA to verify the DaemonSet is not removed")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, sa)
+				g.Expect(err).NotTo(HaveOccurred())
+				sa.ImagePullSecrets = nil
+				err = k8sClient.Update(ctx, sa)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to remove imagePullSecrets from SA")
+			}).Should(Succeed(), "imagePullSecrets should be removed from SA")
+
+			By("Verifying the DaemonSet still exists (skip path: SA check not needed for existing DaemonSet)")
+			Consistently(func(g Gomega) {
+				ds := &appsv1.DaemonSet{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				}, ds)
+				g.Expect(err).NotTo(HaveOccurred(), "the DaemonSet should continue to exist even without SA imagePullSecrets")
+			}, "1s", "100ms").Should(Succeed(), "the DaemonSet should remain when it already exists, regardless of SA imagePullSecrets")
+		})
+	})
 	Context("the webhook shoud deny PodPlacementConfig creation", func() {
 		It("when the ClusterPodPlacementConfig doesn't exist", func() {
 			By("Ensure the ClusterPodPlacementConfig doesn't exist")
@@ -1102,6 +1200,29 @@ func setDeploymentReady(name string, g Gomega) {
 	})
 }
 
+// simulateSAImagePullSecretProvisioning simulates the OpenShift SA controller behavior
+// by adding a fake imagePullSecret to the specified ServiceAccount.
+// In real OpenShift clusters, the SA controller auto-generates a dockercfg secret
+// and populates the SA's ImagePullSecrets field. In envtest, this doesn't happen,
+// so we need to simulate it for the DaemonSet creation to proceed.
+func simulateSAImagePullSecretProvisioning(saName string) {
+	Eventually(func(g Gomega) {
+		sa := &corev1.ServiceAccount{}
+		err := k8sClient.Get(ctx, crclient.ObjectKey{
+			Name:      saName,
+			Namespace: utils.Namespace(),
+		}, sa)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get ServiceAccount "+saName)
+		if len(sa.ImagePullSecrets) == 0 {
+			sa.ImagePullSecrets = []corev1.LocalObjectReference{
+				{Name: saName + "-dockercfg-fake"},
+			}
+			err = k8sClient.Update(ctx, sa)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to update ServiceAccount "+saName+" with imagePullSecrets")
+		}
+	}).Should(Succeed(), "the ServiceAccount "+saName+" should have imagePullSecrets")
+}
+
 // validateReconcile
 // NOTE: this can be used only in integratoin tests as it changes the status of deployments
 func validateReconcile(pluginObjectsSet ...framework.PluginObjectsSet) {
@@ -1109,6 +1230,14 @@ func validateReconcile(pluginObjectsSet ...framework.PluginObjectsSet) {
 		Eventually(func(g Gomega) {
 			setDeploymentReady(name, g)
 		}).Should(Succeed(), "the deployment "+name+" should be ready")
+	}
+	// Simulate OpenShift SA controller by adding imagePullSecrets to the enoexec-event-daemon SA.
+	// Without this, the DaemonSet creation is deferred because envtest has no SA controller.
+	for _, pluginSet := range pluginObjectsSet {
+		if pluginSet == framework.ENoExecPlugin || pluginSet == framework.EnoExecPluginDaemonSet {
+			simulateSAImagePullSecretProvisioning(utils.EnoexecDaemonSet)
+			break
+		}
 	}
 	Eventually(framework.ValidateCreation(k8sClient, ctx, pluginObjectsSet...)).Should(Succeed(), "the ClusterPodPlacementConfig should be created")
 	By("The ClusterPodPlacementConfig is ready")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENoExecEvent plugin deployment reliability by waiting for required ServiceAccount image pull secrets before creating its DaemonSet.
  * Automatically retries reconciliation after prerequisites become available, ensuring the DaemonSet is created successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->