### PR TITLE
WIP:  MULTIARCH-5645: trim container image filesystem to reduce attack surface  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,34 @@ COPY pkg/ pkg/
 RUN GOGC=75 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 RUN GOGC=75 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o enoexec-daemon cmd/enoexec-daemon/main.go
 
+# Trimmer stage: use the runtime image (which has ldd) to discover shared library
+# dependencies and assemble a minimal root filesystem.
+FROM ${RUNTIME_IMAGE} as trimmer
+COPY --from=builder /workspace/manager /workspace/enoexec-daemon /usr/local/bin/
+RUN mkdir -p /runtime/usr/local/bin /runtime/etc/pki/tls/certs /runtime/etc /runtime/lib64 /runtime/lib && \
+    cp /usr/local/bin/manager /usr/local/bin/enoexec-daemon /runtime/usr/local/bin/ && \
+    for bin in /usr/local/bin/manager /usr/local/bin/enoexec-daemon; do \
+        ldd "$bin" 2>/dev/null | grep -oP '(?<==> )\S+' | while read lib; do \
+            dir="/runtime$(dirname "$lib")" && \
+            mkdir -p "$dir" && \
+            cp -L "$lib" "$dir/"; \
+        done; \
+    done && \
+    cp -rL /etc/pki/tls/certs/ca-bundle.crt /runtime/etc/pki/tls/certs/ && \
+    if [ -d /usr/share/zoneinfo ]; then \
+        mkdir -p /runtime/usr/share && \
+        cp -rL /usr/share/zoneinfo /runtime/usr/share/zoneinfo; \
+    fi && \
+    echo "65532:x:65532:65532:nonroot:/:" > /runtime/etc/passwd && \
+    echo "65532:x:65532:" > /runtime/etc/group && \
+    cp -L /lib64/ld-linux-*.so.* /runtime/lib64/ 2>/dev/null; \
+    cp -L /lib/ld-linux-*.so.* /runtime/lib/ 2>/dev/null; \
+    true
 
-# Use UBI minimal as base image to package the manager binary
-FROM ${RUNTIME_IMAGE}
+# Final minimal image with no shell, no package manager, no unnecessary files.
+FROM scratch
+COPY --from=trimmer /runtime/ /
 WORKDIR /
-COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/enoexec-daemon .
-
 USER 65532:65532
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
@@ -65,4 +86,4 @@ LABEL summary="The Multiarch Tuning Operator enhances the user experience for ad
 LABEL io.k8s.display-name="Multiarch Tuning Operator"
 LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/internal/controller/operator/enoexecevent_objects.go
+++ b/internal/controller/operator/enoexecevent_objects.go
@@ -140,7 +140,7 @@ func buildDaemonSetENoExecEvent(serviceAccount string, name string, logVerbosity
 
 							Args: args,
 							Command: []string{
-								"/enoexec-daemon",
+								"/usr/local/bin/enoexec-daemon",
 								fmt.Sprintf("--initial-log-level=%d",
 									logVerbosity),
 							},

--- a/internal/controller/operator/objects.go
+++ b/internal/controller/operator/objects.go
@@ -169,7 +169,7 @@ func buildDeployment(logVerbosity int,
 									logVerbosity),
 							}, args...),
 							Command: []string{
-								"/manager",
+								"/usr/local/bin/manager",
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -27,12 +27,36 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o enoexec-daemon cmd/enoexec-daemon/main.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
-WORKDIR /
-COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/enoexec-daemon .
-COPY LICENSE /licenses/license.txt
+# Trimmer stage: use the runtime image (which has ldd) to discover shared library
+# dependencies and assemble a minimal root filesystem.
+FROM registry.redhat.io/ubi9/ubi-minimal:latest as trimmer
+COPY --from=builder /workspace/manager /workspace/enoexec-daemon /usr/local/bin/
+RUN mkdir -p /runtime/usr/local/bin /runtime/etc/pki/tls/certs /runtime/etc /runtime/lib64 /runtime/lib && \
+    cp /usr/local/bin/manager /usr/local/bin/enoexec-daemon /runtime/usr/local/bin/ && \
+    for bin in /usr/local/bin/manager /usr/local/bin/enoexec-daemon; do \
+        ldd "$bin" 2>/dev/null | grep -oP '(?<==> )\S+' | while read lib; do \
+            dir="/runtime$(dirname "$lib")" && \
+            mkdir -p "$dir" && \
+            cp -L "$lib" "$dir/"; \
+        done; \
+    done && \
+    cp -rL /etc/pki/tls/certs/ca-bundle.crt /runtime/etc/pki/tls/certs/ && \
+    if [ -d /usr/share/zoneinfo ]; then \
+        mkdir -p /runtime/usr/share && \
+        cp -rL /usr/share/zoneinfo /runtime/usr/share/zoneinfo; \
+    fi && \
+    echo "65532:x:65532:65532:nonroot:/:" > /runtime/etc/passwd && \
+    echo "65532:x:65532:" > /runtime/etc/group && \
+    cp -L /lib64/ld-linux-*.so.* /runtime/lib64/ 2>/dev/null; \
+    cp -L /lib/ld-linux-*.so.* /runtime/lib/ 2>/dev/null; \
+    true
+RUN mkdir -p /runtime/licenses
+COPY LICENSE /runtime/licenses/license.txt
 
+# Final minimal image with no shell, no package manager, no unnecessary files.
+FROM scratch
+COPY --from=trimmer /runtime/ /
+WORKDIR /
 USER 65532:65532
 LABEL com.redhat.component="Multiarch Tuning Operator"
 LABEL distribution-scope="public"
@@ -55,5 +79,5 @@ LABEL summary="The Multiarch Tuning Operator enhances the user experience for ad
 LABEL io.k8s.display-name="Multiarch Tuning Operator"
 LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]
 


### PR DESCRIPTION
 utilities that are never used at runtime. These expand the attack surface unnecessarily — especially                                                 
  for the enoexec-daemon, which runs as a privileged container (UID 0) with full kernel access via the                                                 
  privileged SCC. A compromised container with a shell and utilities available is significantly more                                                   
  exploitable than one containing only the required binary and its dependencies.                                                                       
                                                                                                                                                       
  This change was requested by Product Security for MTO 1.3 ([MULTIARCH-5645](https://redhat.atlassian.net/browse/MULTIARCH-5645)).                                                                          
                                                                                                                                                       
  ## What's in the trimmed image                                                                                                                       
                                                                                                                                                       
  | Component | Included |                                                                                                                             
  |-----------|----------|                                                                                                                             
  | `manager` and `enoexec-daemon` binaries | Yes |                                                                                                    
  | Shared libraries (libgpgme, libgpg-error, libassuan, libresolv, libc) | Yes, discovered via `ldd` |                                                
  | Dynamic linker (`ld-linux-*.so.*`) | Yes |                                                                                                         
  | CA certificates (`/etc/pki/tls/certs/ca-bundle.crt`) | Yes |                                                                                       
  | Timezone data (`/usr/share/zoneinfo`) | Yes, if present in base image |                                                                            
  | `/etc/passwd` and `/etc/group` for UID 65532 | Yes |                                                                                               
  | Shell, package manager, RPM database | **No** |                                                                                                    
                                                                                                                                                       
  ## Image size                                                                                                                                        
                                                                                                                                                       
  | | Size |                                                                                                                                           
  |---|---|                                                                                                                                            
  | Before (ubi-minimal) | 343 MB |                                                                                                                    
  | After (scratch + trimmed) | 239 MB |                                                                                                               
  | Reduction | ~30% |                                                                                                                                 
                                                                           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Reduced container image contents for a smaller runtime footprint.
  * Preserved required certificates, timezone data, libraries, licenses, and non-root execution support.
  * Updated service startup paths to ensure manager and daemon components launch correctly in the streamlined images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->